### PR TITLE
Olá!

### DIFF
--- a/smali_classes3/com/random/chat/app/ui/chat/ChatViewModel.smali.bak
+++ b/smali_classes3/com/random/chat/app/ui/chat/ChatViewModel.smali.bak
@@ -1,0 +1,16414 @@
+.class public Lcom/random/chat/app/ui/chat/ChatViewModel;
+.super Landroidx/lifecycle/AndroidViewModel;
+.source "SourceFile"
+
+
+# annotations
+.annotation system Ldalvik/annotation/MemberClasses;
+    value = {
+        Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;,
+        Lcom/random/chat/app/ui/chat/ChatViewModel$UpdateSongTime;
+    }
+.end annotation
+
+
+# static fields
+.field private static final TAG:Ljava/lang/String; = "ChatViewModel"
+
+
+# instance fields
+.field adsController:Lcom/random/chat/app/data/controller/AdsController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field alertSpam:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field alwaysAcceptImages:Z
+
+.field audioFile:Ljava/io/File;
+
+.field audioRecorder:Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;
+
+.field blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field blocked:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field canShowAds:Z
+
+.field changeAllowImages:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field configController:Lcom/random/chat/app/data/controller/ConfigController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+.field handler:Landroid/os/Handler;
+
+.field hideLastSeen:Z
+
+.field idPlaying:Ljava/lang/String;
+
+.field imageBackground:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/String;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field initialized:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field private loadingMore:Z
+
+.field messageController:Lcom/random/chat/app/data/controller/MessageController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field messages:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/util/List<",
+            "Lcom/random/chat/app/data/entity/MessageChat;",
+            ">;>;"
+        }
+    .end annotation
+.end field
+
+.field final messagesCached:Ljava/util/List;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Ljava/util/List<",
+            "Lcom/random/chat/app/data/entity/MessageChat;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field newChat:Z
+
+.field nextActivity:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Lcom/random/chat/app/ui/chat/NextActivity;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field onError:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field presence:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Lcom/random/chat/app/data/entity/Presence;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field presenceController:Lcom/random/chat/app/data/controller/PresenceController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field recordAudioUpdate:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Lcom/random/chat/app/ui/chat/RecordAudioUpdate;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field reportProfileController:Lcom/random/chat/app/data/controller/ReportProfileController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field requestSnackAllowImages:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+.field scheduleRetryAdsThread:Ljava/lang/Thread;
+
+.field scrollBottom:Z
+
+.field sendImageEvent:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Lcom/random/chat/app/ui/chat/SendImageEvent;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field talk:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Lcom/random/chat/app/data/entity/TalkChat;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field talkController:Lcom/random/chat/app/data/controller/TalkController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field talkDeleted:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field timerRecord:Ljava/util/Timer;
+
+.field typing:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Ljava/lang/Boolean;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field typingController:Lcom/random/chat/app/data/controller/TypingController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+.field typingEvent:Landroidx/lifecycle/MutableLiveData;
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "Landroidx/lifecycle/MutableLiveData<",
+            "Lcom/random/chat/app/data/entity/TypingEvent;",
+            ">;"
+        }
+    .end annotation
+.end field
+
+.field userController:Lcom/random/chat/app/data/controller/UserController;
+    .annotation runtime Ljavax/inject/Inject;
+    .end annotation
+.end field
+
+
+# direct methods
+.method public constructor <init>(Landroid/app/Application;)V
+    .locals 2
+    .param p1    # Landroid/app/Application;
+        .annotation build Landroidx/annotation/NonNull;
+        .end annotation
+    .end param
+
+    .line 1
+    invoke-direct {p0, p1}, Landroidx/lifecycle/AndroidViewModel;-><init>(Landroid/app/Application;)V
+
+    .line 2
+    .line 3
+    .line 4
+    new-instance p1, Ljava/util/concurrent/CopyOnWriteArrayList;
+
+    .line 5
+    .line 6
+    invoke-direct {p1}, Ljava/util/concurrent/CopyOnWriteArrayList;-><init>()V
+
+    .line 7
+    .line 8
+    .line 9
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 10
+    .line 11
+    new-instance p1, Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 12
+    .line 13
+    invoke-direct {p1}, Lio/reactivex/disposables/CompositeDisposable;-><init>()V
+
+    .line 14
+    .line 15
+    .line 16
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 17
+    .line 18
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 19
+    .line 20
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 21
+    .line 22
+    .line 23
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 24
+    .line 25
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 26
+    .line 27
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 28
+    .line 29
+    .line 30
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presence:Landroidx/lifecycle/MutableLiveData;
+
+    .line 31
+    .line 32
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 33
+    .line 34
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 35
+    .line 36
+    .line 37
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->requestSnackAllowImages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 38
+    .line 39
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 40
+    .line 41
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 42
+    .line 43
+    .line 44
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blocked:Landroidx/lifecycle/MutableLiveData;
+
+    .line 45
+    .line 46
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 47
+    .line 48
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 49
+    .line 50
+    .line 51
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->imageBackground:Landroidx/lifecycle/MutableLiveData;
+
+    .line 52
+    .line 53
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 54
+    .line 55
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 56
+    .line 57
+    .line 58
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 59
+    .line 60
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 61
+    .line 62
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 63
+    .line 64
+    .line 65
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->typing:Landroidx/lifecycle/MutableLiveData;
+
+    .line 66
+    .line 67
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 68
+    .line 69
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 70
+    .line 71
+    .line 72
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->typingEvent:Landroidx/lifecycle/MutableLiveData;
+
+    .line 73
+    .line 74
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 75
+    .line 76
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 77
+    .line 78
+    .line 79
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->initialized:Landroidx/lifecycle/MutableLiveData;
+
+    .line 80
+    .line 81
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 82
+    .line 83
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 84
+    .line 85
+    .line 86
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->alertSpam:Landroidx/lifecycle/MutableLiveData;
+
+    .line 87
+    .line 88
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 89
+    .line 90
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 91
+    .line 92
+    .line 93
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->changeAllowImages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 94
+    .line 95
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 96
+    .line 97
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 98
+    .line 99
+    .line 100
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkDeleted:Landroidx/lifecycle/MutableLiveData;
+
+    .line 101
+    .line 102
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 103
+    .line 104
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 105
+    .line 106
+    .line 107
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->onError:Landroidx/lifecycle/MutableLiveData;
+
+    .line 108
+    .line 109
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 110
+    .line 111
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 112
+    .line 113
+    .line 114
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->sendImageEvent:Landroidx/lifecycle/MutableLiveData;
+
+    .line 115
+    .line 116
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 117
+    .line 118
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 119
+    .line 120
+    .line 121
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->nextActivity:Landroidx/lifecycle/MutableLiveData;
+
+    .line 122
+    .line 123
+    new-instance p1, Landroidx/lifecycle/MutableLiveData;
+
+    .line 124
+    .line 125
+    invoke-direct {p1}, Landroidx/lifecycle/MutableLiveData;-><init>()V
+
+    .line 126
+    .line 127
+    .line 128
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->recordAudioUpdate:Landroidx/lifecycle/MutableLiveData;
+
+    .line 129
+    .line 130
+    invoke-static {}, Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;->getInstance()Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 131
+    .line 132
+    .line 133
+    move-result-object p1
+
+    .line 134
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 135
+    .line 136
+    new-instance p1, Landroid/os/Handler;
+
+    .line 137
+    .line 138
+    invoke-static {}, Landroid/os/Looper;->getMainLooper()Landroid/os/Looper;
+
+    .line 139
+    .line 140
+    .line 141
+    move-result-object v0
+
+    .line 142
+    invoke-direct {p1, v0}, Landroid/os/Handler;-><init>(Landroid/os/Looper;)V
+
+    .line 143
+    .line 144
+    .line 145
+    iput-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->handler:Landroid/os/Handler;
+
+    .line 146
+    .line 147
+    const/4 p1, 0x0
+
+    .line 148
+    iput-boolean p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->hideLastSeen:Z
+
+    .line 149
+    .line 150
+    iput-boolean p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->alwaysAcceptImages:Z
+
+    .line 151
+    .line 152
+    iput-boolean p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->newChat:Z
+
+    .line 153
+    .line 154
+    iput-boolean p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->scrollBottom:Z
+
+    .line 155
+    .line 156
+    iput-boolean p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->canShowAds:Z
+
+    .line 157
+    .line 158
+    invoke-static {}, Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;->getInstance()Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;
+
+    .line 159
+    .line 160
+    .line 161
+    move-result-object v0
+
+    .line 162
+    iput-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->audioRecorder:Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;
+
+    .line 163
+    .line 164
+    iput-boolean p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->loadingMore:Z
+
+    .line 165
+    .line 166
+    invoke-static {}, Lcom/random/chat/app/MyApplication;->getInstance()Lcom/random/chat/app/MyApplication;
+
+    .line 167
+    .line 168
+    .line 169
+    move-result-object p1
+
+    .line 170
+    invoke-virtual {p1}, Lcom/random/chat/app/MyApplication;->getApplicationComponent()Lcom/random/chat/app/di/ApplicationComponent;
+
+    .line 171
+    .line 172
+    .line 173
+    move-result-object p1
+
+    .line 174
+    invoke-interface {p1, p0}, Lcom/random/chat/app/di/ApplicationComponent;->inject(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 175
+    .line 176
+    .line 177
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 178
+    .line 179
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 180
+    .line 181
+    iget-object v0, v0, Lcom/random/chat/app/data/controller/MessageController;->messageAddEvent:Lio/reactivex/subjects/PublishSubject;
+
+    .line 182
+    .line 183
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 184
+    .line 185
+    .line 186
+    move-result-object v1
+
+    .line 187
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 188
+    .line 189
+    .line 190
+    move-result-object v1
+
+    .line 191
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 192
+    .line 193
+    .line 194
+    move-result-object v1
+
+    .line 195
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 196
+    .line 197
+    .line 198
+    move-result-object v0
+
+    .line 199
+    new-instance v1, Lcom/random/chat/app/ui/chat/b0;
+
+    .line 200
+    .line 201
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/b0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 202
+    .line 203
+    .line 204
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 205
+    .line 206
+    .line 207
+    move-result-object v0
+
+    .line 208
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 209
+    .line 210
+    .line 211
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 212
+    .line 213
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 214
+    .line 215
+    iget-object v0, v0, Lcom/random/chat/app/data/controller/MessageController;->messageUpdateEvent:Lio/reactivex/subjects/PublishSubject;
+
+    .line 216
+    .line 217
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 218
+    .line 219
+    .line 220
+    move-result-object v1
+
+    .line 221
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 222
+    .line 223
+    .line 224
+    move-result-object v1
+
+    .line 225
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 226
+    .line 227
+    .line 228
+    move-result-object v1
+
+    .line 229
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 230
+    .line 231
+    .line 232
+    move-result-object v0
+
+    .line 233
+    new-instance v1, Lcom/random/chat/app/ui/chat/c0;
+
+    .line 234
+    .line 235
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/c0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 236
+    .line 237
+    .line 238
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 239
+    .line 240
+    .line 241
+    move-result-object v0
+
+    .line 242
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 243
+    .line 244
+    .line 245
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 246
+    .line 247
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 248
+    .line 249
+    iget-object v0, v0, Lcom/random/chat/app/data/controller/MessageController;->messageDelEvent:Lio/reactivex/subjects/PublishSubject;
+
+    .line 250
+    .line 251
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 252
+    .line 253
+    .line 254
+    move-result-object v1
+
+    .line 255
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 256
+    .line 257
+    .line 258
+    move-result-object v1
+
+    .line 259
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 260
+    .line 261
+    .line 262
+    move-result-object v1
+
+    .line 263
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 264
+    .line 265
+    .line 266
+    move-result-object v0
+
+    .line 267
+    new-instance v1, Lcom/random/chat/app/ui/chat/d0;
+
+    .line 268
+    .line 269
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/d0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 270
+    .line 271
+    .line 272
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 273
+    .line 274
+    .line 275
+    move-result-object v0
+
+    .line 276
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 277
+    .line 278
+    .line 279
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 280
+    .line 281
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkController:Lcom/random/chat/app/data/controller/TalkController;
+
+    .line 282
+    .line 283
+    invoke-virtual {v0}, Lcom/random/chat/app/data/controller/TalkController;->getTalkUpdatedEvent()Lio/reactivex/subjects/PublishSubject;
+
+    .line 284
+    .line 285
+    .line 286
+    move-result-object v0
+
+    .line 287
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 288
+    .line 289
+    .line 290
+    move-result-object v1
+
+    .line 291
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 292
+    .line 293
+    .line 294
+    move-result-object v1
+
+    .line 295
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 296
+    .line 297
+    .line 298
+    move-result-object v1
+
+    .line 299
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 300
+    .line 301
+    .line 302
+    move-result-object v0
+
+    .line 303
+    new-instance v1, Lcom/random/chat/app/ui/chat/e0;
+
+    .line 304
+    .line 305
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/e0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 306
+    .line 307
+    .line 308
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 309
+    .line 310
+    .line 311
+    move-result-object v0
+
+    .line 312
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 313
+    .line 314
+    .line 315
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 316
+    .line 317
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->typingController:Lcom/random/chat/app/data/controller/TypingController;
+
+    .line 318
+    .line 319
+    iget-object v0, v0, Lcom/random/chat/app/data/controller/TypingController;->typingEvent:Lio/reactivex/subjects/PublishSubject;
+
+    .line 320
+    .line 321
+    invoke-static {}, Lio/reactivex/schedulers/Schedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 322
+    .line 323
+    .line 324
+    move-result-object v1
+
+    .line 325
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 326
+    .line 327
+    .line 328
+    move-result-object v0
+
+    .line 329
+    new-instance v1, Lcom/random/chat/app/ui/chat/f0;
+
+    .line 330
+    .line 331
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/f0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 332
+    .line 333
+    .line 334
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 335
+    .line 336
+    .line 337
+    move-result-object v0
+
+    .line 338
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 339
+    .line 340
+    .line 341
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 342
+    .line 343
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presenceController:Lcom/random/chat/app/data/controller/PresenceController;
+
+    .line 344
+    .line 345
+    iget-object v0, v0, Lcom/random/chat/app/data/controller/PresenceController;->presenceEvent:Lio/reactivex/subjects/PublishSubject;
+
+    .line 346
+    .line 347
+    invoke-static {}, Lio/reactivex/schedulers/Schedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 348
+    .line 349
+    .line 350
+    move-result-object v1
+
+    .line 351
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 352
+    .line 353
+    .line 354
+    move-result-object v0
+
+    .line 355
+    new-instance v1, Lcom/random/chat/app/ui/chat/g0;
+
+    .line 356
+    .line 357
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/g0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 358
+    .line 359
+    .line 360
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 361
+    .line 362
+    .line 363
+    move-result-object v0
+
+    .line 364
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 365
+    .line 366
+    .line 367
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 368
+    .line 369
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 370
+    .line 371
+    iget-object v0, v0, Lcom/random/chat/app/data/controller/MessageController;->gifShareFromKeyboard:Lio/reactivex/subjects/PublishSubject;
+
+    .line 372
+    .line 373
+    invoke-static {}, Lio/reactivex/schedulers/Schedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 374
+    .line 375
+    .line 376
+    move-result-object v1
+
+    .line 377
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 378
+    .line 379
+    .line 380
+    move-result-object v0
+
+    .line 381
+    new-instance v1, Lcom/random/chat/app/ui/chat/h0;
+
+    .line 382
+    .line 383
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/h0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 384
+    .line 385
+    .line 386
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 387
+    .line 388
+    .line 389
+    move-result-object v0
+
+    .line 390
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 391
+    .line 392
+    .line 393
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 394
+    .line 395
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 396
+    .line 397
+    iget-object v0, v0, Lcom/random/chat/app/data/controller/MessageController;->imageShareFromKeyboard:Lio/reactivex/subjects/PublishSubject;
+
+    .line 398
+    .line 399
+    invoke-static {}, Lio/reactivex/schedulers/Schedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 400
+    .line 401
+    .line 402
+    move-result-object v1
+
+    .line 403
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 404
+    .line 405
+    .line 406
+    move-result-object v0
+
+    .line 407
+    new-instance v1, Lcom/random/chat/app/ui/chat/i0;
+
+    .line 408
+    .line 409
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/i0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 410
+    .line 411
+    .line 412
+    invoke-virtual {v0, v1}, Lio/reactivex/Observable;->u(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 413
+    .line 414
+    .line 415
+    move-result-object v0
+
+    .line 416
+    invoke-virtual {p1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 417
+    .line 418
+    .line 419
+    return-void
+    .line 420
+    .line 421
+    .line 422
+    .line 423
+    .line 424
+    .line 425
+    .line 426
+    .line 427
+    .line 428
+    .line 429
+    .line 430
+    .line 431
+    .line 432
+    .line 433
+    .line 434
+    .line 435
+    .line 436
+    .line 437
+    .line 438
+    .line 439
+    .line 440
+    .line 441
+    .line 442
+    .line 443
+    .line 444
+    .line 445
+    .line 446
+    .line 447
+    .line 448
+    .line 449
+    .line 450
+    .line 451
+    .line 452
+    .line 453
+    .line 454
+    .line 455
+    .line 456
+    .line 457
+    .line 458
+    .line 459
+    .line 460
+    .line 461
+    .line 462
+    .line 463
+    .line 464
+    .line 465
+    .line 466
+    .line 467
+    .line 468
+    .line 469
+    .line 470
+    .line 471
+    .line 472
+    .line 473
+    .line 474
+    .line 475
+    .line 476
+    .line 477
+    .line 478
+    .line 479
+    .line 480
+    .line 481
+    .line 482
+    .line 483
+    .line 484
+    .line 485
+    .line 486
+    .line 487
+    .line 488
+    .line 489
+    .line 490
+    .line 491
+    .line 492
+    .line 493
+    .line 494
+    .line 495
+    .line 496
+    .line 497
+    .line 498
+    .line 499
+    .line 500
+    .line 501
+    .line 502
+    .line 503
+    .line 504
+    .line 505
+    .line 506
+    .line 507
+    .line 508
+    .line 509
+    .line 510
+    .line 511
+    .line 512
+    .line 513
+    .line 514
+    .line 515
+    .line 516
+    .line 517
+    .line 518
+    .line 519
+    .line 520
+    .line 521
+    .line 522
+    .line 523
+    .line 524
+    .line 525
+    .line 526
+    .line 527
+    .line 528
+    .line 529
+    .line 530
+    .line 531
+    .line 532
+    .line 533
+    .line 534
+    .line 535
+    .line 536
+    .line 537
+    .line 538
+    .line 539
+    .line 540
+    .line 541
+    .line 542
+    .line 543
+    .line 544
+    .line 545
+    .line 546
+    .line 547
+    .line 548
+    .line 549
+    .line 550
+    .line 551
+    .line 552
+    .line 553
+    .line 554
+    .line 555
+    .line 556
+    .line 557
+    .line 558
+    .line 559
+    .line 560
+    .line 561
+    .line 562
+    .line 563
+    .line 564
+    .line 565
+    .line 566
+    .line 567
+    .line 568
+    .line 569
+    .line 570
+    .line 571
+    .line 572
+    .line 573
+    .line 574
+    .line 575
+    .line 576
+    .line 577
+    .line 578
+    .line 579
+    .line 580
+    .line 581
+    .line 582
+    .line 583
+    .line 584
+    .line 585
+    .line 586
+    .line 587
+    .line 588
+    .line 589
+    .line 590
+    .line 591
+    .line 592
+    .line 593
+    .line 594
+    .line 595
+    .line 596
+    .line 597
+    .line 598
+    .line 599
+    .line 600
+    .line 601
+    .line 602
+    .line 603
+    .line 604
+    .line 605
+    .line 606
+    .line 607
+    .line 608
+    .line 609
+    .line 610
+    .line 611
+    .line 612
+    .line 613
+    .line 614
+    .line 615
+    .line 616
+    .line 617
+    .line 618
+    .line 619
+    .line 620
+    .line 621
+    .line 622
+    .line 623
+    .line 624
+    .line 625
+    .line 626
+    .line 627
+    .line 628
+    .line 629
+    .line 630
+    .line 631
+    .line 632
+    .line 633
+    .line 634
+    .line 635
+    .line 636
+    .line 637
+    .line 638
+    .line 639
+    .line 640
+    .line 641
+    .line 642
+    .line 643
+    .line 644
+    .line 645
+    .line 646
+    .line 647
+    .line 648
+    .line 649
+    .line 650
+    .line 651
+    .line 652
+    .line 653
+    .line 654
+    .line 655
+    .line 656
+    .line 657
+    .line 658
+    .line 659
+    .line 660
+    .line 661
+    .line 662
+    .line 663
+    .line 664
+    .line 665
+    .line 666
+    .line 667
+    .line 668
+    .line 669
+    .line 670
+    .line 671
+    .line 672
+    .line 673
+    .line 674
+    .line 675
+    .line 676
+    .line 677
+    .line 678
+    .line 679
+    .line 680
+    .line 681
+    .line 682
+    .line 683
+    .line 684
+    .line 685
+    .line 686
+    .line 687
+    .line 688
+    .line 689
+    .line 690
+    .line 691
+    .line 692
+    .line 693
+    .line 694
+    .line 695
+    .line 696
+    .line 697
+    .line 698
+    .line 699
+    .line 700
+    .line 701
+    .line 702
+    .line 703
+    .line 704
+    .line 705
+    .line 706
+    .line 707
+    .line 708
+    .line 709
+    .line 710
+    .line 711
+    .line 712
+    .line 713
+    .line 714
+    .line 715
+    .line 716
+    .line 717
+    .line 718
+    .line 719
+    .line 720
+    .line 721
+    .line 722
+    .line 723
+    .line 724
+    .line 725
+    .line 726
+    .line 727
+    .line 728
+    .line 729
+    .line 730
+    .line 731
+    .line 732
+    .line 733
+    .line 734
+    .line 735
+    .line 736
+    .line 737
+    .line 738
+    .line 739
+    .line 740
+    .line 741
+    .line 742
+    .line 743
+    .line 744
+    .line 745
+    .line 746
+    .line 747
+    .line 748
+    .line 749
+    .line 750
+    .line 751
+    .line 752
+    .line 753
+    .line 754
+    .line 755
+    .line 756
+    .line 757
+    .line 758
+    .line 759
+    .line 760
+    .line 761
+    .line 762
+    .line 763
+    .line 764
+    .line 765
+    .line 766
+    .line 767
+    .line 768
+    .line 769
+    .line 770
+    .line 771
+    .line 772
+    .line 773
+    .line 774
+    .line 775
+    .line 776
+    .line 777
+    .line 778
+    .line 779
+    .line 780
+    .line 781
+    .line 782
+    .line 783
+    .line 784
+    .line 785
+    .line 786
+    .line 787
+    .line 788
+    .line 789
+    .line 790
+    .line 791
+    .line 792
+    .line 793
+    .line 794
+    .line 795
+    .line 796
+    .line 797
+    .line 798
+    .line 799
+    .line 800
+    .line 801
+    .line 802
+    .line 803
+    .line 804
+    .line 805
+    .line 806
+    .line 807
+    .line 808
+    .line 809
+    .line 810
+    .line 811
+    .line 812
+    .line 813
+    .line 814
+    .line 815
+    .line 816
+    .line 817
+    .line 818
+    .line 819
+    .line 820
+    .line 821
+    .line 822
+    .line 823
+    .line 824
+    .line 825
+    .line 826
+    .line 827
+    .line 828
+    .line 829
+    .line 830
+    .line 831
+    .line 832
+    .line 833
+    .line 834
+    .line 835
+    .line 836
+    .line 837
+    .line 838
+    .line 839
+    .line 840
+    .line 841
+    .line 842
+    .line 843
+    .line 844
+    .line 845
+    .line 846
+    .line 847
+    .line 848
+    .line 849
+    .line 850
+    .line 851
+    .line 852
+    .line 853
+    .line 854
+    .line 855
+    .line 856
+    .line 857
+    .line 858
+    .line 859
+    .line 860
+    .line 861
+    .line 862
+    .line 863
+    .line 864
+    .line 865
+    .line 866
+    .line 867
+    .line 868
+    .line 869
+    .line 870
+    .line 871
+    .line 872
+    .line 873
+    .line 874
+    .line 875
+    .line 876
+    .line 877
+    .line 878
+    .line 879
+    .line 880
+    .line 881
+    .line 882
+    .line 883
+    .line 884
+    .line 885
+    .line 886
+    .line 887
+    .line 888
+    .line 889
+    .line 890
+    .line 891
+    .line 892
+    .line 893
+    .line 894
+    .line 895
+    .line 896
+    .line 897
+    .line 898
+    .line 899
+    .line 900
+    .line 901
+    .line 902
+    .line 903
+    .line 904
+    .line 905
+    .line 906
+    .line 907
+    .line 908
+    .line 909
+    .line 910
+    .line 911
+    .line 912
+    .line 913
+    .line 914
+    .line 915
+    .line 916
+    .line 917
+    .line 918
+    .line 919
+    .line 920
+    .line 921
+    .line 922
+    .line 923
+    .line 924
+    .line 925
+    .line 926
+    .line 927
+    .line 928
+    .line 929
+    .line 930
+    .line 931
+    .line 932
+    .line 933
+    .line 934
+    .line 935
+    .line 936
+    .line 937
+    .line 938
+    .line 939
+    .line 940
+    .line 941
+    .line 942
+    .line 943
+    .line 944
+    .line 945
+    .line 946
+    .line 947
+    .line 948
+    .line 949
+    .line 950
+    .line 951
+    .line 952
+    .line 953
+    .line 954
+    .line 955
+    .line 956
+    .line 957
+    .line 958
+    .line 959
+    .line 960
+    .line 961
+    .line 962
+    .line 963
+    .line 964
+    .line 965
+    .line 966
+    .line 967
+    .line 968
+    .line 969
+    .line 970
+    .line 971
+    .line 972
+    .line 973
+    .line 974
+    .line 975
+    .line 976
+    .line 977
+    .line 978
+    .line 979
+    .line 980
+    .line 981
+    .line 982
+    .line 983
+    .line 984
+    .line 985
+    .line 986
+    .line 987
+    .line 988
+    .line 989
+    .line 990
+    .line 991
+    .line 992
+    .line 993
+    .line 994
+    .line 995
+    .line 996
+    .line 997
+    .line 998
+    .line 999
+    .line 1000
+    .line 1001
+    .line 1002
+    .line 1003
+    .line 1004
+    .line 1005
+    .line 1006
+    .line 1007
+    .line 1008
+    .line 1009
+    .line 1010
+    .line 1011
+    .line 1012
+    .line 1013
+    .line 1014
+    .line 1015
+.end method
+
+.method public static synthetic A(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$acceptImages$34(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic B(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/Presence;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->onPresence(Lcom/random/chat/app/data/entity/Presence;)V
+
+    return-void
+.end method
+
+.method public static synthetic C(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$initialize$2(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic D(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$block$5(Z)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic E(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/util/List;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$deleteSelectedMessages$24(Ljava/util/List;)V
+
+    return-void
+.end method
+
+.method public static synthetic F(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$updateFavorite$31(Z)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic G(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$stopRecord$44(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;)V
+
+    return-void
+.end method
+
+.method public static synthetic H(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/String;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$changeBackground$10(Ljava/lang/String;)V
+
+    return-void
+.end method
+
+.method public static synthetic I(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$initialize$1(Lcom/random/chat/app/data/entity/TalkChat;)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic J(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/ui/chat/SendImageEvent;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$verifyCanSend$26(Lcom/random/chat/app/ui/chat/SendImageEvent;)V
+
+    return-void
+.end method
+
+.method public static synthetic K(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TypingEvent;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$new$0(Lcom/random/chat/app/data/entity/TypingEvent;)V
+
+    return-void
+.end method
+
+.method public static synthetic L(Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-static {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$markRead$12(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic M(Lcom/random/chat/app/ui/chat/ChatViewModel;ZLjava/io/File;Lcom/random/chat/app/data/entity/TalkChat;)Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2, p3}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$stopRecord$43(ZLjava/io/File;Lcom/random/chat/app/data/entity/TalkChat;)Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic N(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$startRecord$42(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic O(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$block$6(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic P(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$launchUpload$18(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    return-void
+.end method
+
+.method public static synthetic Q(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/util/List;)Ljava/util/List;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$deleteSelectedMessages$23(Ljava/util/List;)Ljava/util/List;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic R(Lcom/random/chat/app/ui/chat/ChatViewModel;I)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$report$3(I)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic S(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/ui/chat/FileShareObject;)Lcom/random/chat/app/ui/chat/SendImageEvent;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$verifyCanShare$27(Lcom/random/chat/app/ui/chat/FileShareObject;)Lcom/random/chat/app/ui/chat/SendImageEvent;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic T(Lcom/random/chat/app/ui/chat/ChatViewModel;ZLjava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$changeAllowImages$20(ZLjava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic U(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->onAddedMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    return-void
+.end method
+
+.method public static synthetic V(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$startPlay$40(Lcom/random/chat/app/data/entity/MessageChat;Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic W(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$startPlay$39(Lcom/random/chat/app/data/entity/MessageChat;)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic X(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$stopPlaying$38(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic Y(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->onUpdatedMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    return-void
+.end method
+
+.method public static synthetic b(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$delete$8(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic c(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/String;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$handleCrop$14(Ljava/lang/String;)V
+
+    return-void
+.end method
+
+.method public static synthetic d(Landroid/content/Intent;)Ljava/lang/String;
+    .locals 0
+
+    .line 1
+    invoke-static {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$handleCrop$13(Landroid/content/Intent;)Ljava/lang/String;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic e(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->onUpdatedTalk(Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    return-void
+.end method
+
+.method public static synthetic f(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/ui/chat/SendImageEvent;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$verifyCanShare$28(Lcom/random/chat/app/ui/chat/SendImageEvent;)V
+
+    return-void
+.end method
+
+.method public static synthetic g(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$sendTyping$35(Z)V
+
+    return-void
+.end method
+
+.method private getFirstMessage()Lcom/random/chat/app/data/entity/MessageChat;
+    .locals 3
+
+    .line 1
+    const/4 v0, 0x0
+
+    .line 2
+    :goto_0
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 3
+    .line 4
+    invoke-interface {v1}, Ljava/util/List;->size()I
+
+    .line 5
+    .line 6
+    .line 7
+    move-result v1
+
+    .line 8
+    if-ge v0, v1, :cond_1
+
+    .line 9
+    .line 10
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 11
+    .line 12
+    invoke-interface {v1, v0}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    .line 13
+    .line 14
+    .line 15
+    move-result-object v1
+
+    .line 16
+    check-cast v1, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 17
+    .line 18
+    instance-of v2, v1, Lcom/random/chat/app/data/entity/MessageSeparator;
+
+    .line 19
+    .line 20
+    if-nez v2, :cond_0
+
+    .line 21
+    .line 22
+    return-object v1
+
+    .line 23
+    :cond_0
+    add-int/lit8 v0, v0, 0x1
+
+    .line 24
+    .line 25
+    goto :goto_0
+
+    .line 26
+    :cond_1
+    const/4 v0, 0x0
+
+    .line 27
+    return-object v0
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method public static synthetic h(Lcom/random/chat/app/ui/chat/ChatViewModel;)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$stopPlaying$37()Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic i(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/String;)Ljava/lang/String;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$changeBackground$9(Ljava/lang/String;)Ljava/lang/String;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic j(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$uploadImage$17(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    return-void
+.end method
+
+.method public static synthetic k(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$sendMessage$22(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic l(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$cleanMessagesChat$29(Z)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method private synthetic lambda$acceptImages$33()Ljava/lang/Boolean;
+    .locals 3
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkController:Lcom/random/chat/app/data/controller/TalkController;
+
+    .line 12
+    .line 13
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 14
+    .line 15
+    .line 16
+    move-result-object v0
+
+    .line 17
+    const/4 v2, 0x1
+
+    .line 18
+    invoke-virtual {v1, v0, v2}, Lcom/random/chat/app/data/controller/TalkController;->verifyImages(Ljava/lang/String;Z)V
+
+    .line 19
+    .line 20
+    .line 21
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 22
+    .line 23
+    return-object v0
+
+    .line 24
+    :catch_0
+    move-exception v0
+
+    .line 25
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 26
+    .line 27
+    .line 28
+    :cond_0
+    sget-object v0, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 29
+    .line 30
+    return-object v0
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method private synthetic lambda$acceptImages$34(Ljava/lang/Boolean;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->requestSnackAllowImages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->o(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$block$5(Z)Ljava/lang/Boolean;
+    .locals 3
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_1
+
+    .line 10
+    .line 11
+    if-eqz p1, :cond_0
+
+    .line 12
+    .line 13
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+
+    .line 14
+    .line 15
+    invoke-virtual {v1, v0}, Lcom/random/chat/app/data/controller/BlockProfileController;->add(Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 16
+    .line 17
+    .line 18
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->typing:Landroidx/lifecycle/MutableLiveData;
+
+    .line 19
+    .line 20
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 21
+    .line 22
+    .line 23
+    move-result-object v0
+
+    .line 24
+    check-cast v0, Ljava/lang/Boolean;
+
+    .line 25
+    .line 26
+    if-eqz v0, :cond_1
+
+    .line 27
+    .line 28
+    invoke-virtual {v0}, Ljava/lang/Boolean;->booleanValue()Z
+
+    .line 29
+    .line 30
+    .line 31
+    move-result v0
+
+    .line 32
+    if-eqz v0, :cond_1
+
+    .line 33
+    .line 34
+    const/4 v0, 0x0
+
+    .line 35
+    invoke-virtual {p0, v0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->sendTyping(Z)V
+
+    .line 36
+    .line 37
+    .line 38
+    goto :goto_1
+
+    .line 39
+    :catch_0
+    move-exception v0
+
+    .line 40
+    goto :goto_0
+
+    .line 41
+    :cond_0
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+
+    .line 42
+    .line 43
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 44
+    .line 45
+    .line 46
+    move-result-object v0
+
+    .line 47
+    invoke-virtual {v1, v0}, Lcom/random/chat/app/data/controller/BlockProfileController;->remove(Ljava/lang/String;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 48
+    .line 49
+    .line 50
+    goto :goto_1
+
+    .line 51
+    :goto_0
+    const-string v1, "ChatViewModel"
+
+    .line 52
+    .line 53
+    invoke-virtual {v0}, Ljava/lang/Throwable;->getLocalizedMessage()Ljava/lang/String;
+
+    .line 54
+    .line 55
+    .line 56
+    move-result-object v2
+
+    .line 57
+    invoke-static {v1, v2, v0}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 58
+    .line 59
+    .line 60
+    :cond_1
+    :goto_1
+    invoke-static {p1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+
+    .line 61
+    .line 62
+    .line 63
+    move-result-object p1
+
+    .line 64
+    return-object p1
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$block$6(Ljava/lang/Boolean;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blocked:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->o(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$changeAllowImages$19(Z)Ljava/lang/Boolean;
+    .locals 3
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_2
+
+    .line 10
+    .line 11
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkController:Lcom/random/chat/app/data/controller/TalkController;
+
+    .line 12
+    .line 13
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 14
+    .line 15
+    .line 16
+    move-result-object v2
+
+    .line 17
+    invoke-virtual {v1, v2, p1}, Lcom/random/chat/app/data/controller/TalkController;->allowImages(Ljava/lang/String;Z)V
+
+    .line 18
+    .line 19
+    .line 20
+    iget-boolean v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->alwaysAcceptImages:Z
+
+    .line 21
+    .line 22
+    if-nez v1, :cond_1
+
+    .line 23
+    .line 24
+    if-eqz p1, :cond_0
+
+    .line 25
+    .line 26
+    goto :goto_0
+
+    .line 27
+    :cond_0
+    const/4 v1, 0x0
+
+    .line 28
+    goto :goto_1
+
+    .line 29
+    :cond_1
+    :goto_0
+    const/4 v1, 0x1
+
+    .line 30
+    :goto_1
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 31
+    .line 32
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 33
+    .line 34
+    .line 35
+    move-result-object v0
+
+    .line 36
+    invoke-virtual {v2, v0, v1}, Lcom/random/chat/app/data/controller/MessageController;->list(Ljava/lang/String;Z)Lcom/random/chat/app/data/entity/MessageList;
+
+    .line 37
+    .line 38
+    .line 39
+    move-result-object v0
+
+    .line 40
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/MessageList;->getFiltered()Ljava/util/List;
+
+    .line 41
+    .line 42
+    .line 43
+    move-result-object v0
+
+    .line 44
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->divideMessageByDate(Ljava/util/List;)Ljava/util/List;
+
+    .line 45
+    .line 46
+    .line 47
+    move-result-object v0
+
+    .line 48
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 49
+    .line 50
+    invoke-interface {v1}, Ljava/util/List;->clear()V
+
+    .line 51
+    .line 52
+    .line 53
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 54
+    .line 55
+    invoke-interface {v1, v0}, Ljava/util/List;->addAll(Ljava/util/Collection;)Z
+
+    .line 56
+    .line 57
+    .line 58
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 59
+    .line 60
+    new-instance v1, Ljava/util/ArrayList;
+
+    .line 61
+    .line 62
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 63
+    .line 64
+    invoke-direct {v1, v2}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 65
+    .line 66
+    .line 67
+    invoke-virtual {v0, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 68
+    .line 69
+    .line 70
+    :cond_2
+    invoke-static {p1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+
+    .line 71
+    .line 72
+    .line 73
+    move-result-object p1
+
+    .line 74
+    return-object p1
+    .line 75
+    .line 76
+    .line 77
+    .line 78
+    .line 79
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method private synthetic lambda$changeAllowImages$20(ZLjava/lang/Boolean;)V
+    .locals 0
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->changeAllowImages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-static {p1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object p1
+
+    .line 7
+    invoke-virtual {p2, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 8
+    .line 9
+    .line 10
+    return-void
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+    .line 23
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$changeBackground$10(Ljava/lang/String;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->imageBackground:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->o(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$changeBackground$9(Ljava/lang/String;)Ljava/lang/String;
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const-string v0, "bg"
+
+    .line 2
+    .line 3
+    if-eqz p1, :cond_0
+
+    .line 4
+    .line 5
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->configController:Lcom/random/chat/app/data/controller/ConfigController;
+
+    .line 6
+    .line 7
+    invoke-virtual {v1, v0, p1}, Lcom/random/chat/app/data/controller/ConfigController;->insert(Ljava/lang/String;Ljava/lang/String;)V
+
+    .line 8
+    .line 9
+    .line 10
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->configController:Lcom/random/chat/app/data/controller/ConfigController;
+
+    .line 11
+    .line 12
+    invoke-virtual {p1}, Lcom/random/chat/app/data/controller/ConfigController;->getBackground()Ljava/lang/String;
+
+    .line 13
+    .line 14
+    .line 15
+    move-result-object p1
+
+    .line 16
+    return-object p1
+
+    .line 17
+    :cond_0
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->configController:Lcom/random/chat/app/data/controller/ConfigController;
+
+    .line 18
+    .line 19
+    const-string v1, "default"
+
+    .line 20
+    .line 21
+    invoke-virtual {p1, v0, v1}, Lcom/random/chat/app/data/controller/ConfigController;->insert(Ljava/lang/String;Ljava/lang/String;)V
+
+    .line 22
+    .line 23
+    .line 24
+    return-object v1
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$cleanMessagesChat$29(Z)Ljava/lang/Boolean;
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkController:Lcom/random/chat/app/data/controller/TalkController;
+
+    .line 12
+    .line 13
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 14
+    .line 15
+    .line 16
+    move-result-object v0
+
+    .line 17
+    invoke-virtual {v1, v0, p1}, Lcom/random/chat/app/data/controller/TalkController;->cleanChat(Ljava/lang/String;Z)V
+
+    .line 18
+    .line 19
+    .line 20
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 21
+    .line 22
+    invoke-interface {p1}, Ljava/util/List;->clear()V
+
+    .line 23
+    .line 24
+    .line 25
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 26
+    .line 27
+    new-instance v0, Ljava/util/ArrayList;
+
+    .line 28
+    .line 29
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 30
+    .line 31
+    invoke-direct {v0, v1}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 32
+    .line 33
+    .line 34
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 35
+    .line 36
+    .line 37
+    goto :goto_0
+
+    .line 38
+    :catch_0
+    move-exception p1
+
+    .line 39
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 40
+    .line 41
+    .line 42
+    :cond_0
+    :goto_0
+    sget-object p1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 43
+    .line 44
+    return-object p1
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private static synthetic lambda$cleanMessagesChat$30(Ljava/lang/Boolean;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const-string p0, "ChatViewModel"
+
+    .line 2
+    .line 3
+    const-string v0, "Messages cleaned"
+
+    .line 4
+    .line 5
+    invoke-static {p0, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    return-void
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$delete$7(ZZ)Ljava/lang/Boolean;
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_1
+
+    .line 10
+    .line 11
+    if-eqz p1, :cond_0
+
+    .line 12
+    .line 13
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+
+    .line 14
+    .line 15
+    invoke-virtual {p1, v0}, Lcom/random/chat/app/data/controller/BlockProfileController;->add(Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 16
+    .line 17
+    .line 18
+    goto :goto_0
+
+    .line 19
+    :catch_0
+    move-exception p1
+
+    .line 20
+    goto :goto_1
+
+    .line 21
+    :cond_0
+    :goto_0
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkController:Lcom/random/chat/app/data/controller/TalkController;
+
+    .line 22
+    .line 23
+    invoke-virtual {p1, v0, p2}, Lcom/random/chat/app/data/controller/TalkController;->deleteInBackground(Lcom/random/chat/app/data/entity/TalkChat;Z)V
+
+    .line 24
+    .line 25
+    .line 26
+    sget-object p1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 27
+    .line 28
+    return-object p1
+
+    .line 29
+    :goto_1
+    const-string p2, "ChatViewModel"
+
+    .line 30
+    .line 31
+    invoke-virtual {p1}, Ljava/lang/Throwable;->getLocalizedMessage()Ljava/lang/String;
+
+    .line 32
+    .line 33
+    .line 34
+    move-result-object v0
+
+    .line 35
+    invoke-static {p2, v0, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 36
+    .line 37
+    .line 38
+    :cond_1
+    sget-object p1, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 39
+    .line 40
+    return-object p1
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$delete$8(Ljava/lang/Boolean;)V
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    invoke-virtual {p1}, Ljava/lang/Boolean;->booleanValue()Z
+
+    .line 2
+    .line 3
+    .line 4
+    move-result v0
+
+    .line 5
+    const-string v1, "ChatViewModel"
+
+    .line 6
+    .line 7
+    if-eqz v0, :cond_0
+
+    .line 8
+    .line 9
+    const-string v0, "deleted"
+
+    .line 10
+    .line 11
+    invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 12
+    .line 13
+    .line 14
+    goto :goto_0
+
+    .line 15
+    :cond_0
+    const-string v0, "talk is null! not deleted"
+
+    .line 16
+    .line 17
+    invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 18
+    .line 19
+    .line 20
+    :goto_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkDeleted:Landroidx/lifecycle/MutableLiveData;
+
+    .line 21
+    .line 22
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 23
+    .line 24
+    .line 25
+    return-void
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$deleteSelectedMessages$23(Ljava/util/List;)Ljava/util/List;
+    .locals 5
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_2
+
+    .line 10
+    .line 11
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    .line 12
+    .line 13
+    .line 14
+    move-result v0
+
+    .line 15
+    new-array v1, v0, [Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 16
+    .line 17
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    .line 18
+    .line 19
+    .line 20
+    move-result v2
+
+    .line 21
+    add-int/lit8 v2, v2, -0x1
+
+    .line 22
+    .line 23
+    :goto_0
+    if-ltz v2, :cond_0
+
+    .line 24
+    .line 25
+    iget-object v3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 26
+    .line 27
+    invoke-interface {p1, v2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    .line 28
+    .line 29
+    .line 30
+    move-result-object v4
+
+    .line 31
+    check-cast v4, Ljava/lang/Integer;
+
+    .line 32
+    .line 33
+    invoke-virtual {v4}, Ljava/lang/Integer;->intValue()I
+
+    .line 34
+    .line 35
+    .line 36
+    move-result v4
+
+    .line 37
+    invoke-interface {v3, v4}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    .line 38
+    .line 39
+    .line 40
+    move-result-object v3
+
+    .line 41
+    check-cast v3, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 42
+    .line 43
+    aput-object v3, v1, v2
+
+    .line 44
+    .line 45
+    add-int/lit8 v2, v2, -0x1
+
+    .line 46
+    .line 47
+    goto :goto_0
+
+    .line 48
+    :catch_0
+    move-exception p1
+
+    .line 49
+    goto :goto_2
+
+    .line 50
+    :cond_0
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 51
+    .line 52
+    invoke-virtual {p1, v1}, Lcom/random/chat/app/data/controller/MessageController;->delete([Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 53
+    .line 54
+    .line 55
+    const/4 p1, 0x0
+
+    .line 56
+    :goto_1
+    if-ge p1, v0, :cond_1
+
+    .line 57
+    .line 58
+    aget-object v2, v1, p1
+
+    .line 59
+    .line 60
+    iget-object v3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 61
+    .line 62
+    invoke-interface {v3, v2}, Ljava/util/List;->remove(Ljava/lang/Object;)Z
+
+    .line 63
+    .line 64
+    .line 65
+    add-int/lit8 p1, p1, 0x1
+
+    .line 66
+    .line 67
+    goto :goto_1
+
+    .line 68
+    :cond_1
+    new-instance p1, Ljava/util/ArrayList;
+
+    .line 69
+    .line 70
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 71
+    .line 72
+    invoke-direct {p1, v0}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 73
+    .line 74
+    .line 75
+    return-object p1
+
+    .line 76
+    :goto_2
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 77
+    .line 78
+    .line 79
+    :cond_2
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 80
+    .line 81
+    invoke-virtual {p1}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 82
+    .line 83
+    .line 84
+    move-result-object p1
+
+    .line 85
+    check-cast p1, Ljava/util/List;
+
+    .line 86
+    .line 87
+    return-object p1
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method private synthetic lambda$deleteSelectedMessages$24(Ljava/util/List;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->o(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private static synthetic lambda$handleCrop$13(Landroid/content/Intent;)Ljava/lang/String;
+    .locals 3
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    invoke-static {p0}, Lcom/yalantis/ucrop/UCrop;->getOutput(Landroid/content/Intent;)Landroid/net/Uri;
+
+    .line 2
+    .line 3
+    .line 4
+    move-result-object p0
+
+    .line 5
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    .line 6
+    .line 7
+    invoke-direct {v0}, Ljava/lang/StringBuilder;-><init>()V
+
+    .line 8
+    .line 9
+    .line 10
+    const-string v1, "upload_"
+
+    .line 11
+    .line 12
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 13
+    .line 14
+    .line 15
+    invoke-static {}, Ljava/util/UUID;->randomUUID()Ljava/util/UUID;
+
+    .line 16
+    .line 17
+    .line 18
+    move-result-object v1
+
+    .line 19
+    invoke-virtual {v1}, Ljava/util/UUID;->toString()Ljava/lang/String;
+
+    .line 20
+    .line 21
+    .line 22
+    move-result-object v1
+
+    .line 23
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 24
+    .line 25
+    .line 26
+    const-string v1, ".jpg"
+
+    .line 27
+    .line 28
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 29
+    .line 30
+    .line 31
+    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    .line 32
+    .line 33
+    .line 34
+    move-result-object v0
+
+    .line 35
+    sget v1, Lcom/random/chat/app/util/AppConstants;->IMAGE_SIZE:I
+
+    .line 36
+    .line 37
+    sget v2, Lcom/random/chat/app/util/AppConstants;->COMPRESS_QUALITY_IMAGE:I
+
+    .line 38
+    .line 39
+    invoke-static {p0, v0, v1, v2}, Lcom/random/chat/app/util/AppUtils;->resizeImg(Landroid/net/Uri;Ljava/lang/String;II)Ljava/io/File;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p0
+
+    .line 43
+    invoke-static {}, Lcom/random/chat/app/MyApplication;->getInstance()Lcom/random/chat/app/MyApplication;
+
+    .line 44
+    .line 45
+    .line 46
+    move-result-object v0
+
+    .line 47
+    invoke-virtual {v0}, Landroid/content/Context;->getApplicationContext()Landroid/content/Context;
+
+    .line 48
+    .line 49
+    .line 50
+    move-result-object v0
+
+    .line 51
+    new-instance v1, Ljava/lang/StringBuilder;
+
+    .line 52
+    .line 53
+    invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
+
+    .line 54
+    .line 55
+    .line 56
+    invoke-static {}, Lcom/random/chat/app/MyApplication;->getInstance()Lcom/random/chat/app/MyApplication;
+
+    .line 57
+    .line 58
+    .line 59
+    move-result-object v2
+
+    .line 60
+    invoke-virtual {v2}, Landroid/content/Context;->getApplicationContext()Landroid/content/Context;
+
+    .line 61
+    .line 62
+    .line 63
+    move-result-object v2
+
+    .line 64
+    invoke-virtual {v2}, Landroid/content/Context;->getPackageName()Ljava/lang/String;
+
+    .line 65
+    .line 66
+    .line 67
+    move-result-object v2
+
+    .line 68
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 69
+    .line 70
+    .line 71
+    const-string v2, ".fileprovider"
+
+    .line 72
+    .line 73
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 74
+    .line 75
+    .line 76
+    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    .line 77
+    .line 78
+    .line 79
+    move-result-object v1
+
+    .line 80
+    invoke-static {v0, v1, p0}, Landroidx/core/content/FileProvider;->f(Landroid/content/Context;Ljava/lang/String;Ljava/io/File;)Landroid/net/Uri;
+
+    .line 81
+    .line 82
+    .line 83
+    move-result-object p0
+
+    .line 84
+    invoke-virtual {p0}, Landroid/net/Uri;->toString()Ljava/lang/String;
+
+    .line 85
+    .line 86
+    .line 87
+    move-result-object p0
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 88
+    return-object p0
+
+    .line 89
+    :catch_0
+    move-exception p0
+
+    .line 90
+    invoke-static {p0}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 91
+    .line 92
+    .line 93
+    const-string p0, ""
+
+    .line 94
+    .line 95
+    return-object p0
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method private synthetic lambda$handleCrop$14(Ljava/lang/String;)V
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->isEmpty(Ljava/lang/String;)Z
+
+    .line 2
+    .line 3
+    .line 4
+    move-result v0
+
+    .line 5
+    if-nez v0, :cond_0
+
+    .line 6
+    .line 7
+    sget-object v0, Lcom/random/chat/app/data/entity/type/MessageType;->IMAGE:Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 8
+    .line 9
+    const/4 v1, 0x0
+
+    .line 10
+    invoke-virtual {p0, p1, v0, v1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->uploadImage(Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 11
+    .line 12
+    .line 13
+    :cond_0
+    return-void
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$initialize$1(Lcom/random/chat/app/data/entity/TalkChat;)Ljava/lang/Boolean;
+    .locals 4
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const-string v0, "false"
+
+    .line 2
+    .line 3
+    :try_start_0
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->configController:Lcom/random/chat/app/data/controller/ConfigController;
+
+    .line 4
+    .line 5
+    invoke-virtual {v1}, Lcom/random/chat/app/data/controller/ConfigController;->loadCache()V
+
+    .line 6
+    .line 7
+    .line 8
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+
+    .line 9
+    .line 10
+    invoke-virtual {v1}, Lcom/random/chat/app/data/controller/BlockProfileController;->loadCache()V
+
+    .line 11
+    .line 12
+    .line 13
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->adsController:Lcom/random/chat/app/data/controller/AdsController;
+
+    .line 14
+    .line 15
+    invoke-virtual {v1}, Lcom/random/chat/app/data/controller/AdsController;->canShowAds()Z
+
+    .line 16
+    .line 17
+    .line 18
+    move-result v1
+
+    .line 19
+    iput-boolean v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->canShowAds:Z
+
+    .line 20
+    .line 21
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->configController:Lcom/random/chat/app/data/controller/ConfigController;
+
+    .line 22
+    .line 23
+    const-string v2, "last_seen"
+
+    .line 24
+    .line 25
+    invoke-virtual {v1, v2, v0}, Lcom/random/chat/app/data/controller/ConfigController;->getConfigOrDefault(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+
+    .line 26
+    .line 27
+    .line 28
+    move-result-object v1
+
+    .line 29
+    invoke-static {v1}, Ljava/lang/Boolean;->parseBoolean(Ljava/lang/String;)Z
+
+    .line 30
+    .line 31
+    .line 32
+    move-result v1
+
+    .line 33
+    iput-boolean v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->hideLastSeen:Z
+
+    .line 34
+    .line 35
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->configController:Lcom/random/chat/app/data/controller/ConfigController;
+
+    .line 36
+    .line 37
+    const-string v2, "always_accept_image"
+
+    .line 38
+    .line 39
+    invoke-virtual {v1, v2, v0}, Lcom/random/chat/app/data/controller/ConfigController;->getConfigOrDefault(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object v0
+
+    .line 43
+    const-string v1, "true"
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, v1}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    move-result v0
+
+    .line 49
+    iput-boolean v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->alwaysAcceptImages:Z
+
+    .line 50
+    .line 51
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blocked:Landroidx/lifecycle/MutableLiveData;
+
+    .line 52
+    .line 53
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+
+    .line 54
+    .line 55
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 56
+    .line 57
+    .line 58
+    move-result-object v2
+
+    .line 59
+    invoke-virtual {v1, v2}, Lcom/random/chat/app/data/controller/BlockProfileController;->verifyBlocked(Ljava/lang/String;)Z
+
+    .line 60
+    .line 61
+    .line 62
+    move-result v1
+
+    .line 63
+    invoke-static {v1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+
+    .line 64
+    .line 65
+    .line 66
+    move-result-object v1
+
+    .line 67
+    invoke-virtual {v0, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 68
+    .line 69
+    .line 70
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->imageBackground:Landroidx/lifecycle/MutableLiveData;
+
+    .line 71
+    .line 72
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->configController:Lcom/random/chat/app/data/controller/ConfigController;
+
+    .line 73
+    .line 74
+    const-string v2, "bg"
+
+    .line 75
+    .line 76
+    invoke-virtual {v1, v2}, Lcom/random/chat/app/data/controller/ConfigController;->getConfig(Ljava/lang/String;)Ljava/lang/String;
+
+    .line 77
+    .line 78
+    .line 79
+    move-result-object v1
+
+    .line 80
+    invoke-virtual {v0, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 81
+    .line 82
+    .line 83
+    iget-boolean v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->alwaysAcceptImages:Z
+
+    .line 84
+    .line 85
+    const/4 v1, 0x1
+
+    .line 86
+    if-nez v0, :cond_1
+
+    .line 87
+    .line 88
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->isAllowImages()Z
+
+    .line 89
+    .line 90
+    .line 91
+    move-result v0
+
+    .line 92
+    if-eqz v0, :cond_0
+
+    .line 93
+    .line 94
+    goto :goto_0
+
+    .line 95
+    :cond_0
+    const/4 v0, 0x0
+
+    .line 96
+    goto :goto_1
+
+    .line 97
+    :catch_0
+    move-exception p1
+
+    .line 98
+    goto :goto_2
+
+    .line 99
+    :cond_1
+    :goto_0
+    const/4 v0, 0x1
+
+    .line 100
+    :goto_1
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 101
+    .line 102
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 103
+    .line 104
+    .line 105
+    move-result-object v3
+
+    .line 106
+    invoke-virtual {v2, v3, v0}, Lcom/random/chat/app/data/controller/MessageController;->list(Ljava/lang/String;Z)Lcom/random/chat/app/data/entity/MessageList;
+
+    .line 107
+    .line 108
+    .line 109
+    move-result-object v0
+
+    .line 110
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/MessageList;->getFiltered()Ljava/util/List;
+
+    .line 111
+    .line 112
+    .line 113
+    move-result-object v0
+
+    .line 114
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->divideMessageByDate(Ljava/util/List;)Ljava/util/List;
+
+    .line 115
+    .line 116
+    .line 117
+    move-result-object v0
+
+    .line 118
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 119
+    .line 120
+    invoke-interface {v2, v0}, Ljava/util/List;->addAll(Ljava/util/Collection;)Z
+
+    .line 121
+    .line 122
+    .line 123
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 124
+    .line 125
+    new-instance v3, Ljava/util/ArrayList;
+
+    .line 126
+    .line 127
+    invoke-direct {v3, v0}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 128
+    .line 129
+    .line 130
+    invoke-virtual {v2, v3}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 131
+    .line 132
+    .line 133
+    iput-boolean v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->scrollBottom:Z
+
+    .line 134
+    .line 135
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presenceController:Lcom/random/chat/app/data/controller/PresenceController;
+
+    .line 136
+    .line 137
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 138
+    .line 139
+    .line 140
+    move-result-object v1
+
+    .line 141
+    invoke-virtual {v0, v1}, Lcom/random/chat/app/data/controller/PresenceController;->subscribePresence(Ljava/lang/String;)V
+
+    .line 142
+    .line 143
+    .line 144
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->isVerifyImages()Z
+
+    .line 145
+    .line 146
+    .line 147
+    move-result p1
+
+    .line 148
+    if-eqz p1, :cond_2
+
+    .line 149
+    .line 150
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->requestSnackAllowImages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 151
+    .line 152
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 153
+    .line 154
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 155
+    .line 156
+    .line 157
+    :cond_2
+    sget-object p1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 158
+    .line 159
+    return-object p1
+
+    .line 160
+    :goto_2
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 161
+    .line 162
+    .line 163
+    sget-object p1, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 164
+    .line 165
+    return-object p1
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method private synthetic lambda$initialize$2(Ljava/lang/Boolean;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->initialized:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->o(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$launchDownloadAudio$36(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 1
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1, p2}, Lcom/random/chat/app/data/controller/MessageController;->startUploadMessage(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+    .line 23
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$launchUpload$18(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 1
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1, p2}, Lcom/random/chat/app/data/controller/MessageController;->startUploadMessage(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+    .line 23
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$markRead$11()Ljava/lang/Boolean;
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 12
+    .line 13
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 14
+    .line 15
+    .line 16
+    move-result-object v0
+
+    .line 17
+    invoke-virtual {v1, v0}, Lcom/random/chat/app/data/controller/MessageController;->markRead(Ljava/lang/String;)V
+
+    .line 18
+    .line 19
+    .line 20
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 21
+    .line 22
+    return-object v0
+
+    .line 23
+    :cond_0
+    sget-object v0, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 24
+    .line 25
+    return-object v0
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method private static synthetic lambda$markRead$12(Ljava/lang/Boolean;)V
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    .line 2
+    .line 3
+    invoke-direct {v0}, Ljava/lang/StringBuilder;-><init>()V
+
+    .line 4
+    .line 5
+    .line 6
+    const-string v1, "markRead "
+
+    .line 7
+    .line 8
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 9
+    .line 10
+    .line 11
+    invoke-virtual {v0, p0}, Ljava/lang/StringBuilder;->append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
+
+    .line 12
+    .line 13
+    .line 14
+    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object p0
+
+    .line 18
+    const-string v0, "ChatViewModel"
+
+    .line 19
+    .line 20
+    invoke-static {v0, p0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 21
+    .line 22
+    .line 23
+    return-void
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$new$0(Lcom/random/chat/app/data/entity/TypingEvent;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->typingEvent:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$report$3(I)Ljava/lang/Boolean;
+    .locals 7
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    move-object v5, v0
+
+    .line 8
+    check-cast v5, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 9
+    .line 10
+    if-eqz v5, :cond_1
+
+    .line 11
+    .line 12
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->reportProfileController:Lcom/random/chat/app/data/controller/ReportProfileController;
+
+    .line 13
+    .line 14
+    int-to-long v2, p1
+
+    .line 15
+    const/16 v0, 0x66
+
+    .line 16
+    .line 17
+    if-ne p1, v0, :cond_0
+
+    .line 18
+    .line 19
+    const/4 p1, 0x1
+
+    .line 20
+    const/4 v6, 0x1
+
+    .line 21
+    goto :goto_0
+
+    .line 22
+    :cond_0
+    const/4 p1, 0x0
+
+    .line 23
+    const/4 v6, 0x0
+
+    .line 24
+    :goto_0
+    const-string v4, "REPORT"
+
+    .line 25
+    .line 26
+    invoke-virtual/range {v1 .. v6}, Lcom/random/chat/app/data/controller/ReportProfileController;->add(JLjava/lang/String;Lcom/random/chat/app/data/entity/TalkChat;Z)V
+
+    .line 27
+    .line 28
+    .line 29
+    sget-object p1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 30
+    .line 31
+    return-object p1
+
+    .line 32
+    :cond_1
+    sget-object p1, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 33
+    .line 34
+    return-object p1
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private static synthetic lambda$report$4(Ljava/lang/Boolean;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    invoke-virtual {p0}, Ljava/lang/Boolean;->booleanValue()Z
+
+    .line 2
+    .line 3
+    .line 4
+    move-result p0
+
+    .line 5
+    const-string v0, "ChatViewModel"
+
+    .line 6
+    .line 7
+    if-eqz p0, :cond_0
+
+    .line 8
+    .line 9
+    const-string p0, "reported"
+
+    .line 10
+    .line 11
+    invoke-static {v0, p0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 12
+    .line 13
+    .line 14
+    goto :goto_0
+
+    .line 15
+    :cond_0
+    const-string p0, "talk is null! not reported"
+
+    .line 16
+    .line 17
+    invoke-static {v0, p0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 18
+    .line 19
+    .line 20
+    :goto_0
+    return-void
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$sendMessage$21(Lcom/random/chat/app/data/entity/MessageChat;)Ljava/lang/Boolean;
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->clone()Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 12
+    .line 13
+    .line 14
+    move-result-object v0
+
+    .line 15
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 16
+    .line 17
+    invoke-virtual {v1, p1, v0}, Lcom/random/chat/app/data/controller/MessageController;->insertTextMessage(Lcom/random/chat/app/data/entity/MessageChat;Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 18
+    .line 19
+    .line 20
+    iget-boolean v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->newChat:Z
+
+    .line 21
+    .line 22
+    if-eqz v1, :cond_0
+
+    .line 23
+    .line 24
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkController:Lcom/random/chat/app/data/controller/TalkController;
+
+    .line 25
+    .line 26
+    invoke-virtual {v1, p1, v0}, Lcom/random/chat/app/data/controller/TalkController;->checkTalkExistMessage(Lcom/random/chat/app/data/entity/MessageChat;Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 27
+    .line 28
+    .line 29
+    sget-object p1, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 30
+    .line 31
+    return-object p1
+
+    .line 32
+    :catch_0
+    move-exception p1
+
+    .line 33
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 34
+    .line 35
+    .line 36
+    :cond_0
+    sget-object p1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 37
+    .line 38
+    return-object p1
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$sendMessage$22(Ljava/lang/Boolean;)V
+    .locals 0
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const/4 p1, 0x0
+
+    .line 2
+    iput-boolean p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->newChat:Z
+
+    .line 3
+    .line 4
+    return-void
+    .line 5
+    .line 6
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$sendTyping$35(Z)V
+    .locals 2
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presence:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/Presence;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/Presence;->isOnline()Z
+
+    .line 12
+    .line 13
+    .line 14
+    move-result v0
+
+    .line 15
+    if-eqz v0, :cond_0
+
+    .line 16
+    .line 17
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 18
+    .line 19
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 20
+    .line 21
+    .line 22
+    move-result-object v0
+
+    .line 23
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 24
+    .line 25
+    if-eqz v0, :cond_0
+
+    .line 26
+    .line 27
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->typingController:Lcom/random/chat/app/data/controller/TypingController;
+
+    .line 28
+    .line 29
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 30
+    .line 31
+    .line 32
+    move-result-object v0
+
+    .line 33
+    invoke-virtual {v1, v0, p1}, Lcom/random/chat/app/data/controller/TypingController;->sendTyping(Ljava/lang/String;Z)V
+
+    .line 34
+    .line 35
+    .line 36
+    goto :goto_0
+
+    .line 37
+    :catch_0
+    move-exception p1
+
+    .line 38
+    goto :goto_1
+
+    .line 39
+    :cond_0
+    :goto_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->typing:Landroidx/lifecycle/MutableLiveData;
+
+    .line 40
+    .line 41
+    invoke-static {p1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+
+    .line 42
+    .line 43
+    .line 44
+    move-result-object p1
+
+    .line 45
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 46
+    .line 47
+    .line 48
+    goto :goto_2
+
+    .line 49
+    :goto_1
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 50
+    .line 51
+    .line 52
+    :goto_2
+    return-void
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$startPlay$39(Lcom/random/chat/app/data/entity/MessageChat;)Ljava/lang/Boolean;
+    .locals 7
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 2
+    .line 3
+    .line 4
+    move-result-object v0
+
+    .line 5
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->isEmpty(Ljava/lang/String;)Z
+
+    .line 6
+    .line 7
+    .line 8
+    move-result v0
+
+    .line 9
+    if-nez v0, :cond_0
+
+    .line 10
+    .line 11
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 12
+    .line 13
+    .line 14
+    move-result-object v0
+
+    .line 15
+    const-string v1, "http"
+
+    .line 16
+    .line 17
+    invoke-virtual {v0, v1}, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
+
+    .line 18
+    .line 19
+    .line 20
+    move-result v0
+
+    .line 21
+    if-eqz v0, :cond_0
+
+    .line 22
+    .line 23
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 24
+    .line 25
+    invoke-virtual {v0, p1}, Lcom/random/chat/app/data/controller/MessageController;->startDownloadMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 26
+    .line 27
+    .line 28
+    sget-object p1, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 29
+    .line 30
+    return-object p1
+
+    .line 31
+    :catch_0
+    move-exception p1
+
+    .line 32
+    goto :goto_0
+
+    .line 33
+    :cond_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 34
+    .line 35
+    invoke-virtual {v0}, Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;->stopPlay()Z
+
+    .line 36
+    .line 37
+    .line 38
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getFinalTime()D
+
+    .line 39
+    .line 40
+    .line 41
+    move-result-wide v0
+
+    .line 42
+    const-wide/16 v2, 0x0
+
+    .line 43
+    .line 44
+    cmpl-double v4, v0, v2
+
+    .line 45
+    .line 46
+    if-lez v4, :cond_1
+
+    .line 47
+    .line 48
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getFinalTime()D
+
+    .line 49
+    .line 50
+    .line 51
+    move-result-wide v0
+
+    .line 52
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getStartTime()D
+
+    .line 53
+    .line 54
+    .line 55
+    move-result-wide v4
+
+    .line 56
+    cmpl-double v6, v0, v4
+
+    .line 57
+    .line 58
+    if-nez v6, :cond_1
+
+    .line 59
+    .line 60
+    invoke-virtual {p1, v2, v3}, Lcom/random/chat/app/data/entity/MessageChat;->setStartTime(D)V
+
+    .line 61
+    .line 62
+    .line 63
+    const-wide/16 v0, 0x0
+
+    .line 64
+    .line 65
+    invoke-virtual {p1, v0, v1}, Lcom/random/chat/app/data/entity/MessageChat;->setProgress(J)V
+
+    .line 66
+    .line 67
+    .line 68
+    invoke-virtual {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->updateMessageInListEvent(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 69
+    .line 70
+    .line 71
+    :cond_1
+    sget-object p1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 72
+    .line 73
+    return-object p1
+
+    .line 74
+    :goto_0
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 75
+    .line 76
+    .line 77
+    sget-object p1, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 78
+    .line 79
+    return-object p1
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method private synthetic lambda$startPlay$40(Lcom/random/chat/app/data/entity/MessageChat;Ljava/lang/Boolean;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    invoke-virtual {p2}, Ljava/lang/Boolean;->booleanValue()Z
+
+    .line 2
+    .line 3
+    .line 4
+    move-result p2
+
+    .line 5
+    if-eqz p2, :cond_0
+
+    .line 6
+    .line 7
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 8
+    .line 9
+    .line 10
+    move-result-object p2
+
+    .line 11
+    iput-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->idPlaying:Ljava/lang/String;
+
+    .line 12
+    .line 13
+    const/4 p2, 0x1
+
+    .line 14
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setPlaying(Z)V
+
+    .line 15
+    .line 16
+    .line 17
+    new-instance p2, Ljava/io/File;
+
+    .line 18
+    .line 19
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 20
+    .line 21
+    .line 22
+    move-result-object v0
+
+    .line 23
+    invoke-direct {p2, v0}, Ljava/io/File;-><init>(Ljava/lang/String;)V
+
+    .line 24
+    .line 25
+    .line 26
+    invoke-static {p2}, Lcom/random/chat/app/ui/chat/androidaudio/PlayConfig;->file(Ljava/io/File;)Lcom/random/chat/app/ui/chat/androidaudio/PlayConfig$Builder;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object p2
+
+    .line 30
+    const/4 v0, 0x0
+
+    .line 31
+    invoke-virtual {p2, v0}, Lcom/random/chat/app/ui/chat/androidaudio/PlayConfig$Builder;->looping(Z)Lcom/random/chat/app/ui/chat/androidaudio/PlayConfig$Builder;
+
+    .line 32
+    .line 33
+    .line 34
+    move-result-object p2
+
+    .line 35
+    invoke-virtual {p2}, Lcom/random/chat/app/ui/chat/androidaudio/PlayConfig$Builder;->build()Lcom/random/chat/app/ui/chat/androidaudio/PlayConfig;
+
+    .line 36
+    .line 37
+    .line 38
+    move-result-object p2
+
+    .line 39
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 40
+    .line 41
+    invoke-virtual {v0, p2}, Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;->play(Lcom/random/chat/app/ui/chat/androidaudio/PlayConfig;)Lio/reactivex/Observable;
+
+    .line 42
+    .line 43
+    .line 44
+    move-result-object p2
+
+    .line 45
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 46
+    .line 47
+    .line 48
+    move-result-object v0
+
+    .line 49
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 50
+    .line 51
+    .line 52
+    move-result-object v0
+
+    .line 53
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 54
+    .line 55
+    .line 56
+    move-result-object v0
+
+    .line 57
+    invoke-virtual {p2, v0}, Lio/reactivex/Observable;->y(Lio/reactivex/Scheduler;)Lio/reactivex/Observable;
+
+    .line 58
+    .line 59
+    .line 60
+    move-result-object p2
+
+    .line 61
+    new-instance v0, Lcom/random/chat/app/ui/chat/ChatViewModel$2;
+
+    .line 62
+    .line 63
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel$2;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 64
+    .line 65
+    .line 66
+    invoke-virtual {p2, v0}, Lio/reactivex/Observable;->a(Lio/reactivex/Observer;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 67
+    .line 68
+    .line 69
+    goto :goto_0
+
+    .line 70
+    :catch_0
+    move-exception p1
+
+    .line 71
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 72
+    .line 73
+    .line 74
+    :cond_0
+    :goto_0
+    return-void
+    .line 75
+    .line 76
+    .line 77
+    .line 78
+    .line 79
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+    .line 221
+    .line 222
+    .line 223
+    .line 224
+    .line 225
+    .line 226
+    .line 227
+    .line 228
+    .line 229
+    .line 230
+.end method
+
+.method private synthetic lambda$startRecord$41()Ljava/lang/Boolean;
+    .locals 8
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    const-string v0, "RandoChat"
+
+    .line 2
+    .line 3
+    invoke-static {v0}, Lcom/random/chat/app/util/StorageUtils;->getAvailableAudiosStorageDir(Ljava/lang/String;)Ljava/io/File;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    new-instance v7, Ljava/io/File;
+
+    .line 8
+    .line 9
+    new-instance v1, Ljava/lang/StringBuilder;
+
+    .line 10
+    .line 11
+    invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
+
+    .line 12
+    .line 13
+    .line 14
+    invoke-static {}, Ljava/lang/System;->nanoTime()J
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-wide v2
+
+    .line 18
+    invoke-virtual {v1, v2, v3}, Ljava/lang/StringBuilder;->append(J)Ljava/lang/StringBuilder;
+
+    .line 19
+    .line 20
+    .line 21
+    const-string v2, ".file.m4a"
+
+    .line 22
+    .line 23
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 24
+    .line 25
+    .line 26
+    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-direct {v7, v0, v1}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    .line 31
+    .line 32
+    .line 33
+    iput-object v7, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->audioFile:Ljava/io/File;
+
+    .line 34
+    .line 35
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->audioRecorder:Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;
+
+    .line 36
+    .line 37
+    const/4 v2, 0x1
+
+    .line 38
+    const/4 v3, 0x2
+
+    .line 39
+    const/4 v4, 0x3
+
+    .line 40
+    const/16 v5, 0x5622
+
+    .line 41
+    .line 42
+    const/16 v6, 0x5622
+
+    .line 43
+    .line 44
+    invoke-virtual/range {v1 .. v7}, Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;->prepareRecord(IIIIILjava/io/File;)Z
+
+    .line 45
+    .line 46
+    .line 47
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 48
+    .line 49
+    return-object v0
+
+    .line 50
+    :catch_0
+    move-exception v0
+
+    .line 51
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 52
+    .line 53
+    .line 54
+    sget-object v0, Ljava/lang/Boolean;->FALSE:Ljava/lang/Boolean;
+
+    .line 55
+    .line 56
+    return-object v0
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method private synthetic lambda$startRecord$42(Ljava/lang/Boolean;)V
+    .locals 7
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    invoke-virtual {p1}, Ljava/lang/Boolean;->booleanValue()Z
+
+    .line 2
+    .line 3
+    .line 4
+    move-result p1
+
+    .line 5
+    if-eqz p1, :cond_0
+
+    .line 6
+    .line 7
+    :try_start_0
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->audioRecorder:Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;
+
+    .line 8
+    .line 9
+    invoke-virtual {p1}, Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;->startRecord()Z
+
+    .line 10
+    .line 11
+    .line 12
+    const-string p1, "ChatViewModel"
+
+    .line 13
+    .line 14
+    const-string v0, "recording audio..."
+
+    .line 15
+    .line 16
+    invoke-static {p1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 17
+    .line 18
+    .line 19
+    new-instance v1, Ljava/util/Timer;
+
+    .line 20
+    .line 21
+    invoke-direct {v1}, Ljava/util/Timer;-><init>()V
+
+    .line 22
+    .line 23
+    .line 24
+    iput-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->timerRecord:Ljava/util/Timer;
+
+    .line 25
+    .line 26
+    new-instance v2, Lcom/random/chat/app/ui/chat/ChatViewModel$3;
+
+    .line 27
+    .line 28
+    invoke-direct {v2, p0}, Lcom/random/chat/app/ui/chat/ChatViewModel$3;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 29
+    .line 30
+    .line 31
+    const-wide/16 v3, 0x0
+
+    .line 32
+    .line 33
+    const-wide/16 v5, 0x64
+
+    .line 34
+    .line 35
+    invoke-virtual/range {v1 .. v6}, Ljava/util/Timer;->schedule(Ljava/util/TimerTask;JJ)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 36
+    .line 37
+    .line 38
+    goto :goto_0
+
+    .line 39
+    :catch_0
+    move-exception p1
+
+    .line 40
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 41
+    .line 42
+    .line 43
+    :cond_0
+    :goto_0
+    return-void
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$stopPlaying$37()Ljava/lang/Boolean;
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const/4 v0, 0x0
+
+    .line 2
+    :try_start_0
+    iput-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->idPlaying:Ljava/lang/String;
+
+    .line 3
+    .line 4
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 5
+    .line 6
+    invoke-virtual {v0}, Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;->stopPlay()Z
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 7
+    .line 8
+    .line 9
+    goto :goto_0
+
+    .line 10
+    :catch_0
+    move-exception v0
+
+    .line 11
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 12
+    .line 13
+    .line 14
+    :goto_0
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 15
+    .line 16
+    return-object v0
+    .line 17
+    .line 18
+.end method
+
+.method private synthetic lambda$stopPlaying$38(Ljava/lang/Boolean;)V
+    .locals 0
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    invoke-virtual {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->stopPlayingStatus()V
+
+    .line 2
+    .line 3
+    .line 4
+    return-void
+    .line 5
+    .line 6
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$stopRecord$43(ZLjava/io/File;Lcom/random/chat/app/data/entity/TalkChat;)Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;
+    .locals 8
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const/4 v0, 0x0
+
+    .line 2
+    const/4 v1, 0x0
+
+    .line 3
+    :try_start_0
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->timerRecord:Ljava/util/Timer;
+
+    .line 4
+    .line 5
+    if-eqz v2, :cond_0
+
+    .line 6
+    .line 7
+    invoke-virtual {v2}, Ljava/util/Timer;->cancel()V
+
+    .line 8
+    .line 9
+    .line 10
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->timerRecord:Ljava/util/Timer;
+
+    .line 11
+    .line 12
+    invoke-virtual {v2}, Ljava/util/Timer;->purge()I
+
+    .line 13
+    .line 14
+    .line 15
+    iput-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->timerRecord:Ljava/util/Timer;
+
+    .line 16
+    .line 17
+    goto :goto_0
+
+    .line 18
+    :catch_0
+    move-exception p1
+
+    .line 19
+    goto/16 :goto_1
+
+    .line 20
+    .line 21
+    :cond_0
+    :goto_0
+    invoke-static {}, Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;->getInstance()Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;
+
+    .line 22
+    .line 23
+    .line 24
+    move-result-object v2
+
+    .line 25
+    invoke-virtual {v2}, Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;->progress()I
+
+    .line 26
+    .line 27
+    .line 28
+    move-result v2
+
+    .line 29
+    invoke-static {}, Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;->getInstance()Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;
+
+    .line 30
+    .line 31
+    .line 32
+    move-result-object v3
+
+    .line 33
+    invoke-virtual {v3}, Lcom/random/chat/app/ui/chat/androidaudio/AudioRecorder;->stopRecord()I
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 34
+    .line 35
+    .line 36
+    const-string v3, "ChatViewModel"
+
+    .line 37
+    .line 38
+    if-nez p1, :cond_1
+
+    .line 39
+    .line 40
+    if-lez v2, :cond_2
+
+    .line 41
+    .line 42
+    :try_start_1
+    new-instance p1, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 43
+    .line 44
+    int-to-long v4, v2
+
+    .line 45
+    const-wide/16 v6, 0x3e8
+
+    .line 46
+    .line 47
+    mul-long v4, v4, v6
+
+    .line 48
+    .line 49
+    invoke-static {v4, v5}, Lcom/random/chat/app/util/AppUtils;->getDateFromSeconds(J)Ljava/lang/String;
+
+    .line 50
+    .line 51
+    .line 52
+    move-result-object v4
+
+    .line 53
+    const/4 v5, 0x1
+
+    .line 54
+    invoke-direct {p1, v4, v5}, Lcom/random/chat/app/data/entity/MessageChat;-><init>(Ljava/lang/String;Z)V
+
+    .line 55
+    .line 56
+    .line 57
+    invoke-virtual {p2}, Ljava/io/File;->getPath()Ljava/lang/String;
+
+    .line 58
+    .line 59
+    .line 60
+    move-result-object p2
+
+    .line 61
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setUrl(Ljava/lang/String;)V
+
+    .line 62
+    .line 63
+    .line 64
+    new-instance p2, Ljava/util/Date;
+
+    .line 65
+    .line 66
+    invoke-direct {p2}, Ljava/util/Date;-><init>()V
+
+    .line 67
+    .line 68
+    .line 69
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setDateSent(Ljava/util/Date;)V
+
+    .line 70
+    .line 71
+    .line 72
+    sget-object p2, Lcom/random/chat/app/data/entity/type/MessageType;->AUDIO:Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 73
+    .line 74
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setType(Lcom/random/chat/app/data/entity/type/MessageType;)V
+
+    .line 75
+    .line 76
+    .line 77
+    sget-object p2, Lcom/random/chat/app/data/entity/type/StatusType;->SEND:Lcom/random/chat/app/data/entity/type/StatusType;
+
+    .line 78
+    .line 79
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setStatus(Lcom/random/chat/app/data/entity/type/StatusType;)V
+
+    .line 80
+    .line 81
+    .line 82
+    mul-int/lit16 v2, v2, 0x3e8
+
+    .line 83
+    .line 84
+    invoke-virtual {p1, v2}, Lcom/random/chat/app/data/entity/MessageChat;->setSeconds(I)V
+
+    .line 85
+    .line 86
+    .line 87
+    invoke-virtual {p1, v1}, Lcom/random/chat/app/data/entity/MessageChat;->setFailed(Z)V
+
+    .line 88
+    .line 89
+    .line 90
+    invoke-virtual {p1, v5}, Lcom/random/chat/app/data/entity/MessageChat;->setStarted(Z)V
+
+    .line 91
+    .line 92
+    .line 93
+    invoke-virtual {p1, v1}, Lcom/random/chat/app/data/entity/MessageChat;->setFinished(Z)V
+
+    .line 94
+    .line 95
+    .line 96
+    invoke-static {v1}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    .line 97
+    .line 98
+    .line 99
+    move-result-object p2
+
+    .line 100
+    invoke-virtual {p2}, Ljava/lang/Integer;->longValue()J
+
+    .line 101
+    .line 102
+    .line 103
+    move-result-wide v6
+
+    .line 104
+    invoke-virtual {p1, v6, v7}, Lcom/random/chat/app/data/entity/MessageChat;->setProgress(J)V
+
+    .line 105
+    .line 106
+    .line 107
+    invoke-virtual {p3}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 108
+    .line 109
+    .line 110
+    move-result-object p2
+
+    .line 111
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setIdProfile(Ljava/lang/String;)V
+
+    .line 112
+    .line 113
+    .line 114
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->userController:Lcom/random/chat/app/data/controller/UserController;
+
+    .line 115
+    .line 116
+    invoke-virtual {p2}, Lcom/random/chat/app/data/controller/UserController;->getUserId()Ljava/lang/String;
+
+    .line 117
+    .line 118
+    .line 119
+    move-result-object p2
+
+    .line 120
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setIdProfileFrom(Ljava/lang/String;)V
+
+    .line 121
+    .line 122
+    .line 123
+    invoke-static {}, Lcom/random/chat/app/util/AppUtils;->msgUid()Ljava/lang/String;
+
+    .line 124
+    .line 125
+    .line 126
+    move-result-object p2
+
+    .line 127
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setIdServer(Ljava/lang/String;)V
+
+    .line 128
+    .line 129
+    .line 130
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 131
+    .line 132
+    invoke-virtual {p2, p1, p3}, Lcom/random/chat/app/data/controller/MessageController;->insertImageUpload(Lcom/random/chat/app/data/entity/MessageChat;Lcom/random/chat/app/data/entity/TalkChat;)J
+
+    .line 133
+    .line 134
+    .line 135
+    move-result-wide p2
+
+    .line 136
+    invoke-virtual {p1, p2, p3}, Lcom/random/chat/app/data/entity/MessageChat;->setId(J)V
+
+    .line 137
+    .line 138
+    .line 139
+    new-instance p2, Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;
+
+    .line 140
+    .line 141
+    invoke-direct {p2, p1, v5}, Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;-><init>(Lcom/random/chat/app/data/entity/MessageChat;Z)V
+    :try_end_1
+    .catch Ljava/lang/Exception; {:try_start_1 .. :try_end_1} :catch_1
+
+    .line 142
+    .line 143
+    .line 144
+    return-object p2
+
+    .line 145
+    :catch_1
+    move-exception p1
+
+    .line 146
+    :try_start_2
+    invoke-virtual {p1}, Ljava/lang/Throwable;->getLocalizedMessage()Ljava/lang/String;
+
+    .line 147
+    .line 148
+    .line 149
+    move-result-object p2
+
+    .line 150
+    invoke-static {v3, p2, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 151
+    .line 152
+    .line 153
+    goto :goto_2
+
+    .line 154
+    :cond_1
+    invoke-virtual {p2}, Ljava/io/File;->delete()Z
+
+    .line 155
+    .line 156
+    .line 157
+    move-result p1
+
+    .line 158
+    if-nez p1, :cond_2
+
+    .line 159
+    .line 160
+    const-string p1, "Error delete audio file"
+
+    .line 161
+    .line 162
+    invoke-static {v3, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;)I
+    :try_end_2
+    .catch Ljava/lang/Exception; {:try_start_2 .. :try_end_2} :catch_0
+
+    .line 163
+    .line 164
+    .line 165
+    goto :goto_2
+
+    .line 166
+    :goto_1
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 167
+    .line 168
+    .line 169
+    :cond_2
+    :goto_2
+    new-instance p1, Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;
+
+    .line 170
+    .line 171
+    invoke-direct {p1, v0, v1}, Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;-><init>(Lcom/random/chat/app/data/entity/MessageChat;Z)V
+
+    .line 172
+    .line 173
+    .line 174
+    return-object p1
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+    .line 221
+    .line 222
+    .line 223
+    .line 224
+    .line 225
+    .line 226
+    .line 227
+    .line 228
+    .line 229
+    .line 230
+    .line 231
+    .line 232
+    .line 233
+    .line 234
+    .line 235
+    .line 236
+    .line 237
+    .line 238
+    .line 239
+    .line 240
+    .line 241
+    .line 242
+    .line 243
+    .line 244
+    .line 245
+    .line 246
+    .line 247
+    .line 248
+    .line 249
+    .line 250
+    .line 251
+    .line 252
+    .line 253
+    .line 254
+    .line 255
+    .line 256
+    .line 257
+    .line 258
+    .line 259
+    .line 260
+    .line 261
+    .line 262
+    .line 263
+    .line 264
+    .line 265
+    .line 266
+    .line 267
+    .line 268
+    .line 269
+    .line 270
+    .line 271
+    .line 272
+    .line 273
+    .line 274
+    .line 275
+    .line 276
+    .line 277
+    .line 278
+    .line 279
+    .line 280
+    .line 281
+    .line 282
+    .line 283
+    .line 284
+    .line 285
+    .line 286
+    .line 287
+    .line 288
+    .line 289
+    .line 290
+    .line 291
+    .line 292
+    .line 293
+    .line 294
+    .line 295
+    .line 296
+    .line 297
+    .line 298
+    .line 299
+    .line 300
+    .line 301
+    .line 302
+    .line 303
+    .line 304
+    .line 305
+    .line 306
+    .line 307
+    .line 308
+    .line 309
+    .line 310
+    .line 311
+    .line 312
+    .line 313
+    .line 314
+    .line 315
+    .line 316
+    .line 317
+    .line 318
+    .line 319
+    .line 320
+    .line 321
+    .line 322
+    .line 323
+    .line 324
+    .line 325
+    .line 326
+    .line 327
+    .line 328
+    .line 329
+    .line 330
+    .line 331
+    .line 332
+    .line 333
+    .line 334
+    .line 335
+    .line 336
+    .line 337
+    .line 338
+    .line 339
+    .line 340
+    .line 341
+    .line 342
+    .line 343
+    .line 344
+    .line 345
+    .line 346
+    .line 347
+    .line 348
+    .line 349
+    .line 350
+    .line 351
+    .line 352
+    .line 353
+    .line 354
+    .line 355
+    .line 356
+    .line 357
+    .line 358
+    .line 359
+    .line 360
+    .line 361
+    .line 362
+    .line 363
+    .line 364
+    .line 365
+    .line 366
+    .line 367
+    .line 368
+    .line 369
+    .line 370
+    .line 371
+    .line 372
+    .line 373
+    .line 374
+    .line 375
+    .line 376
+    .line 377
+    .line 378
+    .line 379
+    .line 380
+    .line 381
+    .line 382
+    .line 383
+    .line 384
+    .line 385
+    .line 386
+    .line 387
+    .line 388
+    .line 389
+    .line 390
+    .line 391
+    .line 392
+    .line 393
+    .line 394
+    .line 395
+    .line 396
+    .line 397
+    .line 398
+    .line 399
+    .line 400
+    .line 401
+    .line 402
+    .line 403
+    .line 404
+    .line 405
+    .line 406
+    .line 407
+    .line 408
+    .line 409
+    .line 410
+    .line 411
+    .line 412
+    .line 413
+    .line 414
+    .line 415
+    .line 416
+    .line 417
+    .line 418
+    .line 419
+    .line 420
+    .line 421
+    .line 422
+    .line 423
+    .line 424
+    .line 425
+    .line 426
+    .line 427
+    .line 428
+    .line 429
+    .line 430
+    .line 431
+    .line 432
+    .line 433
+    .line 434
+    .line 435
+    .line 436
+    .line 437
+    .line 438
+    .line 439
+    .line 440
+    .line 441
+    .line 442
+    .line 443
+    .line 444
+    .line 445
+    .line 446
+    .line 447
+    .line 448
+    .line 449
+    .line 450
+    .line 451
+    .line 452
+    .line 453
+    .line 454
+    .line 455
+    .line 456
+    .line 457
+    .line 458
+    .line 459
+    .line 460
+    .line 461
+    .line 462
+    .line 463
+    .line 464
+    .line 465
+    .line 466
+    .line 467
+    .line 468
+    .line 469
+    .line 470
+    .line 471
+    .line 472
+    .line 473
+    .line 474
+    .line 475
+    .line 476
+    .line 477
+    .line 478
+    .line 479
+    .line 480
+    .line 481
+    .line 482
+    .line 483
+    .line 484
+    .line 485
+    .line 486
+    .line 487
+    .line 488
+    .line 489
+    .line 490
+    .line 491
+    .line 492
+    .line 493
+    .line 494
+    .line 495
+    .line 496
+    .line 497
+    .line 498
+    .line 499
+    .line 500
+    .line 501
+    .line 502
+    .line 503
+    .line 504
+    .line 505
+    .line 506
+    .line 507
+    .line 508
+    .line 509
+    .line 510
+    .line 511
+    .line 512
+    .line 513
+    .line 514
+    .line 515
+    .line 516
+    .line 517
+    .line 518
+    .line 519
+    .line 520
+    .line 521
+    .line 522
+    .line 523
+    .line 524
+    .line 525
+    .line 526
+    .line 527
+    .line 528
+    .line 529
+    .line 530
+    .line 531
+    .line 532
+    .line 533
+    .line 534
+    .line 535
+    .line 536
+    .line 537
+    .line 538
+    .line 539
+    .line 540
+    .line 541
+    .line 542
+    .line 543
+    .line 544
+    .line 545
+    .line 546
+    .line 547
+    .line 548
+    .line 549
+    .line 550
+    .line 551
+    .line 552
+    .line 553
+    .line 554
+    .line 555
+    .line 556
+    .line 557
+    .line 558
+    .line 559
+    .line 560
+    .line 561
+    .line 562
+    .line 563
+    .line 564
+    .line 565
+    .line 566
+    .line 567
+    .line 568
+    .line 569
+    .line 570
+    .line 571
+    .line 572
+    .line 573
+    .line 574
+    .line 575
+    .line 576
+    .line 577
+    .line 578
+    .line 579
+    .line 580
+    .line 581
+    .line 582
+    .line 583
+    .line 584
+    .line 585
+    .line 586
+    .line 587
+    .line 588
+    .line 589
+    .line 590
+    .line 591
+    .line 592
+    .line 593
+    .line 594
+    .line 595
+    .line 596
+    .line 597
+    .line 598
+    .line 599
+    .line 600
+    .line 601
+    .line 602
+    .line 603
+    .line 604
+    .line 605
+    .line 606
+    .line 607
+    .line 608
+    .line 609
+    .line 610
+    .line 611
+    .line 612
+    .line 613
+    .line 614
+    .line 615
+    .line 616
+    .line 617
+    .line 618
+    .line 619
+    .line 620
+    .line 621
+    .line 622
+    .line 623
+    .line 624
+    .line 625
+    .line 626
+    .line 627
+    .line 628
+    .line 629
+    .line 630
+    .line 631
+    .line 632
+    .line 633
+    .line 634
+    .line 635
+    .line 636
+    .line 637
+    .line 638
+    .line 639
+    .line 640
+    .line 641
+    .line 642
+    .line 643
+    .line 644
+    .line 645
+    .line 646
+    .line 647
+    .line 648
+    .line 649
+    .line 650
+    .line 651
+    .line 652
+    .line 653
+    .line 654
+    .line 655
+    .line 656
+    .line 657
+    .line 658
+    .line 659
+    .line 660
+    .line 661
+    .line 662
+    .line 663
+    .line 664
+    .line 665
+    .line 666
+    .line 667
+    .line 668
+    .line 669
+    .line 670
+    .line 671
+    .line 672
+    .line 673
+    .line 674
+    .line 675
+    .line 676
+    .line 677
+    .line 678
+    .line 679
+    .line 680
+    .line 681
+    .line 682
+    .line 683
+    .line 684
+    .line 685
+    .line 686
+    .line 687
+    .line 688
+    .line 689
+    .line 690
+    .line 691
+    .line 692
+    .line 693
+    .line 694
+    .line 695
+    .line 696
+    .line 697
+    .line 698
+    .line 699
+    .line 700
+    .line 701
+    .line 702
+    .line 703
+    .line 704
+    .line 705
+    .line 706
+    .line 707
+    .line 708
+    .line 709
+    .line 710
+    .line 711
+    .line 712
+    .line 713
+    .line 714
+    .line 715
+    .line 716
+    .line 717
+    .line 718
+    .line 719
+    .line 720
+    .line 721
+    .line 722
+    .line 723
+    .line 724
+    .line 725
+    .line 726
+    .line 727
+    .line 728
+    .line 729
+    .line 730
+    .line 731
+    .line 732
+    .line 733
+    .line 734
+    .line 735
+    .line 736
+    .line 737
+    .line 738
+    .line 739
+    .line 740
+    .line 741
+    .line 742
+    .line 743
+    .line 744
+    .line 745
+    .line 746
+    .line 747
+    .line 748
+    .line 749
+    .line 750
+    .line 751
+    .line 752
+    .line 753
+    .line 754
+    .line 755
+    .line 756
+    .line 757
+    .line 758
+    .line 759
+    .line 760
+    .line 761
+    .line 762
+    .line 763
+    .line 764
+    .line 765
+    .line 766
+    .line 767
+    .line 768
+    .line 769
+    .line 770
+    .line 771
+    .line 772
+    .line 773
+    .line 774
+    .line 775
+    .line 776
+    .line 777
+    .line 778
+    .line 779
+    .line 780
+    .line 781
+    .line 782
+    .line 783
+    .line 784
+    .line 785
+    .line 786
+    .line 787
+    .line 788
+    .line 789
+    .line 790
+    .line 791
+    .line 792
+    .line 793
+    .line 794
+    .line 795
+    .line 796
+    .line 797
+    .line 798
+    .line 799
+    .line 800
+    .line 801
+    .line 802
+    .line 803
+    .line 804
+    .line 805
+    .line 806
+    .line 807
+    .line 808
+    .line 809
+    .line 810
+    .line 811
+    .line 812
+    .line 813
+    .line 814
+    .line 815
+    .line 816
+    .line 817
+    .line 818
+    .line 819
+    .line 820
+    .line 821
+    .line 822
+    .line 823
+    .line 824
+    .line 825
+    .line 826
+    .line 827
+    .line 828
+    .line 829
+    .line 830
+    .line 831
+    .line 832
+    .line 833
+    .line 834
+    .line 835
+    .line 836
+    .line 837
+    .line 838
+    .line 839
+    .line 840
+    .line 841
+    .line 842
+    .line 843
+    .line 844
+    .line 845
+    .line 846
+    .line 847
+    .line 848
+    .line 849
+    .line 850
+    .line 851
+    .line 852
+    .line 853
+    .line 854
+    .line 855
+    .line 856
+    .line 857
+    .line 858
+    .line 859
+    .line 860
+    .line 861
+    .line 862
+    .line 863
+    .line 864
+    .line 865
+    .line 866
+    .line 867
+    .line 868
+    .line 869
+    .line 870
+    .line 871
+    .line 872
+    .line 873
+    .line 874
+    .line 875
+    .line 876
+    .line 877
+    .line 878
+    .line 879
+    .line 880
+    .line 881
+    .line 882
+    .line 883
+    .line 884
+    .line 885
+    .line 886
+    .line 887
+    .line 888
+    .line 889
+    .line 890
+    .line 891
+    .line 892
+    .line 893
+    .line 894
+    .line 895
+    .line 896
+    .line 897
+    .line 898
+    .line 899
+    .line 900
+    .line 901
+    .line 902
+    .line 903
+    .line 904
+    .line 905
+    .line 906
+    .line 907
+    .line 908
+    .line 909
+    .line 910
+    .line 911
+    .line 912
+    .line 913
+    .line 914
+    .line 915
+    .line 916
+    .line 917
+    .line 918
+    .line 919
+    .line 920
+    .line 921
+    .line 922
+    .line 923
+    .line 924
+    .line 925
+    .line 926
+.end method
+
+.method private synthetic lambda$stopRecord$44(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;)V
+    .locals 1
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 2
+    .line 3
+    iget-object p2, p2, Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;->messageChat:Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 4
+    .line 5
+    invoke-virtual {v0, p1, p2}, Lcom/random/chat/app/data/controller/MessageController;->startUploadMessage(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 6
+    .line 7
+    .line 8
+    return-void
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+    .line 23
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$stopRecord$45(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;)V
+    .locals 4
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->recordAudioUpdate:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    new-instance v1, Lcom/random/chat/app/ui/chat/RecordAudioUpdate;
+
+    .line 4
+    .line 5
+    const/4 v2, 0x0
+
+    .line 6
+    const-string v3, "00:00"
+
+    .line 7
+    .line 8
+    invoke-direct {v1, v2, v3}, Lcom/random/chat/app/ui/chat/RecordAudioUpdate;-><init>(ZLjava/lang/String;)V
+
+    .line 9
+    .line 10
+    .line 11
+    invoke-virtual {v0, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 12
+    .line 13
+    .line 14
+    iget-boolean v0, p2, Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;->needUpload:Z
+
+    .line 15
+    .line 16
+    if-eqz v0, :cond_0
+
+    .line 17
+    .line 18
+    new-instance v0, Lcom/random/chat/app/ui/chat/Y;
+
+    .line 19
+    .line 20
+    invoke-direct {v0, p0, p1, p2}, Lcom/random/chat/app/ui/chat/Y;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;)V
+
+    .line 21
+    .line 22
+    .line 23
+    invoke-static {v0}, Lcom/random/chat/app/util/SingletonExecutor;->executeSocket(Ljava/lang/Runnable;)V
+
+    .line 24
+    .line 25
+    .line 26
+    :cond_0
+    return-void
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$updateFavorite$31(Z)Ljava/lang/Boolean;
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talkController:Lcom/random/chat/app/data/controller/TalkController;
+
+    .line 12
+    .line 13
+    invoke-virtual {v1, v0, p1}, Lcom/random/chat/app/data/controller/TalkController;->updateFavorite(Lcom/random/chat/app/data/entity/TalkChat;Z)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 14
+    .line 15
+    .line 16
+    goto :goto_0
+
+    .line 17
+    :catch_0
+    move-exception p1
+
+    .line 18
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 19
+    .line 20
+    .line 21
+    :cond_0
+    :goto_0
+    sget-object p1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 22
+    .line 23
+    return-object p1
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private static synthetic lambda$updateFavorite$32(Ljava/lang/Boolean;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const-string p0, "ChatViewModel"
+
+    .line 2
+    .line 3
+    const-string v0, "Messages cleaned"
+
+    .line 4
+    .line 5
+    invoke-static {p0, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    return-void
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$uploadImage$15(Lcom/random/chat/app/data/entity/MessageChat;Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/TalkChat;)Lcom/random/chat/app/data/entity/MessageChat;
+    .locals 3
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    if-eqz p1, :cond_0
+
+    .line 2
+    .line 3
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->clone()Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object p1
+
+    .line 7
+    return-object p1
+
+    .line 8
+    :cond_0
+    new-instance p1, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 9
+    .line 10
+    invoke-direct {p1}, Lcom/random/chat/app/data/entity/MessageChat;-><init>()V
+
+    .line 11
+    .line 12
+    .line 13
+    const/4 v0, 0x1
+
+    .line 14
+    invoke-virtual {p1, v0}, Lcom/random/chat/app/data/entity/MessageChat;->setMine(Z)V
+
+    .line 15
+    .line 16
+    .line 17
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setUrl(Ljava/lang/String;)V
+
+    .line 18
+    .line 19
+    .line 20
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setUrlThumb(Ljava/lang/String;)V
+
+    .line 21
+    .line 22
+    .line 23
+    new-instance p2, Ljava/util/Date;
+
+    .line 24
+    .line 25
+    invoke-direct {p2}, Ljava/util/Date;-><init>()V
+
+    .line 26
+    .line 27
+    .line 28
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setDateSent(Ljava/util/Date;)V
+
+    .line 29
+    .line 30
+    .line 31
+    invoke-virtual {p1, p3}, Lcom/random/chat/app/data/entity/MessageChat;->setType(Lcom/random/chat/app/data/entity/type/MessageType;)V
+
+    .line 32
+    .line 33
+    .line 34
+    sget-object p2, Lcom/random/chat/app/data/entity/type/StatusType;->SEND:Lcom/random/chat/app/data/entity/type/StatusType;
+
+    .line 35
+    .line 36
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setStatus(Lcom/random/chat/app/data/entity/type/StatusType;)V
+
+    .line 37
+    .line 38
+    .line 39
+    const/4 p2, 0x0
+
+    .line 40
+    invoke-static {p2}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    .line 41
+    .line 42
+    .line 43
+    move-result-object p3
+
+    .line 44
+    invoke-virtual {p3}, Ljava/lang/Integer;->longValue()J
+
+    .line 45
+    .line 46
+    .line 47
+    move-result-wide v1
+
+    .line 48
+    invoke-virtual {p1, v1, v2}, Lcom/random/chat/app/data/entity/MessageChat;->setProgress(J)V
+
+    .line 49
+    .line 50
+    .line 51
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setFailed(Z)V
+
+    .line 52
+    .line 53
+    .line 54
+    invoke-virtual {p1, v0}, Lcom/random/chat/app/data/entity/MessageChat;->setStarted(Z)V
+
+    .line 55
+    .line 56
+    .line 57
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setFinished(Z)V
+
+    .line 58
+    .line 59
+    .line 60
+    invoke-virtual {p4}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 61
+    .line 62
+    .line 63
+    move-result-object p2
+
+    .line 64
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setIdTalk(Ljava/lang/String;)V
+
+    .line 65
+    .line 66
+    .line 67
+    invoke-virtual {p4}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 68
+    .line 69
+    .line 70
+    move-result-object p2
+
+    .line 71
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setIdProfile(Ljava/lang/String;)V
+
+    .line 72
+    .line 73
+    .line 74
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->userController:Lcom/random/chat/app/data/controller/UserController;
+
+    .line 75
+    .line 76
+    invoke-virtual {p2}, Lcom/random/chat/app/data/controller/UserController;->getUserId()Ljava/lang/String;
+
+    .line 77
+    .line 78
+    .line 79
+    move-result-object p2
+
+    .line 80
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setIdProfileFrom(Ljava/lang/String;)V
+
+    .line 81
+    .line 82
+    .line 83
+    invoke-static {}, Lcom/random/chat/app/util/AppUtils;->msgUid()Ljava/lang/String;
+
+    .line 84
+    .line 85
+    .line 86
+    move-result-object p2
+
+    .line 87
+    invoke-virtual {p1, p2}, Lcom/random/chat/app/data/entity/MessageChat;->setIdServer(Ljava/lang/String;)V
+
+    .line 88
+    .line 89
+    .line 90
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 91
+    .line 92
+    invoke-virtual {p2, p1, p4}, Lcom/random/chat/app/data/controller/MessageController;->insertImageUpload(Lcom/random/chat/app/data/entity/MessageChat;Lcom/random/chat/app/data/entity/TalkChat;)J
+
+    .line 93
+    .line 94
+    .line 95
+    move-result-wide p2
+
+    .line 96
+    invoke-virtual {p1, p2, p3}, Lcom/random/chat/app/data/entity/MessageChat;->setId(J)V
+
+    .line 97
+    .line 98
+    .line 99
+    return-object p1
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+    .line 221
+    .line 222
+    .line 223
+    .line 224
+    .line 225
+    .line 226
+    .line 227
+    .line 228
+    .line 229
+    .line 230
+    .line 231
+    .line 232
+    .line 233
+    .line 234
+    .line 235
+    .line 236
+    .line 237
+    .line 238
+.end method
+
+.method private synthetic lambda$uploadImage$16(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 1
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1, p2}, Lcom/random/chat/app/data/controller/MessageController;->startUploadMessage(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+    .line 23
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$uploadImage$17(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/M0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1, p2}, Lcom/random/chat/app/ui/chat/M0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lcom/random/chat/app/util/SingletonExecutor;->executeSocket(Ljava/lang/Runnable;)V
+
+    .line 7
+    .line 8
+    .line 9
+    return-void
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+    .line 23
+    .line 24
+    .line 25
+    .line 26
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+.end method
+
+.method private synthetic lambda$verifyCanSend$25(I)Lcom/random/chat/app/ui/chat/SendImageEvent;
+    .locals 6
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const/4 v0, 0x0
+
+    .line 2
+    :try_start_0
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 3
+    .line 4
+    invoke-virtual {v1}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 5
+    .line 6
+    .line 7
+    move-result-object v1
+
+    .line 8
+    check-cast v1, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 9
+    .line 10
+    if-eqz v1, :cond_1
+
+    .line 11
+    .line 12
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+
+    .line 13
+    .line 14
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v3
+
+    .line 18
+    invoke-virtual {v2, v3}, Lcom/random/chat/app/data/controller/BlockProfileController;->verifyBlocked(Ljava/lang/String;)Z
+
+    .line 19
+    .line 20
+    .line 21
+    move-result v2
+
+    .line 22
+    invoke-virtual {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->uploadBlocked()Ljava/util/Date;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v3
+
+    .line 26
+    iget-object v4, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 27
+    .line 28
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 29
+    .line 30
+    .line 31
+    move-result-object v1
+
+    .line 32
+    const/4 v5, 0x2
+
+    .line 33
+    invoke-virtual {v4, v1, v5}, Lcom/random/chat/app/data/controller/MessageController;->haveMessagesReceived(Ljava/lang/String;I)Z
+
+    .line 34
+    .line 35
+    .line 36
+    move-result v1
+
+    .line 37
+    if-nez v2, :cond_0
+
+    .line 38
+    .line 39
+    if-nez v3, :cond_0
+
+    .line 40
+    .line 41
+    if-eqz v1, :cond_0
+
+    .line 42
+    .line 43
+    const/4 v1, 0x1
+
+    .line 44
+    goto :goto_0
+
+    .line 45
+    :cond_0
+    const/4 v1, 0x0
+
+    .line 46
+    :goto_0
+    new-instance v2, Lcom/random/chat/app/ui/chat/SendImageEvent;
+
+    .line 47
+    .line 48
+    invoke-direct {v2, v1, v3, p1}, Lcom/random/chat/app/ui/chat/SendImageEvent;-><init>(ZLjava/util/Date;I)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 49
+    .line 50
+    .line 51
+    return-object v2
+
+    .line 52
+    :catch_0
+    move-exception v1
+
+    .line 53
+    invoke-static {v1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 54
+    .line 55
+    .line 56
+    :cond_1
+    new-instance v1, Lcom/random/chat/app/ui/chat/SendImageEvent;
+
+    .line 57
+    .line 58
+    const/4 v2, 0x0
+
+    .line 59
+    invoke-direct {v1, v0, v2, p1}, Lcom/random/chat/app/ui/chat/SendImageEvent;-><init>(ZLjava/util/Date;I)V
+
+    .line 60
+    .line 61
+    .line 62
+    return-object v1
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$verifyCanSend$26(Lcom/random/chat/app/ui/chat/SendImageEvent;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->sendImageEvent:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method private synthetic lambda$verifyCanShare$27(Lcom/random/chat/app/ui/chat/FileShareObject;)Lcom/random/chat/app/ui/chat/SendImageEvent;
+    .locals 7
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    const/16 v0, 0x6a
+
+    .line 2
+    .line 3
+    const/4 v1, 0x0
+
+    .line 4
+    :try_start_0
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 5
+    .line 6
+    invoke-virtual {v2}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object v2
+
+    .line 10
+    check-cast v2, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 11
+    .line 12
+    if-eqz v2, :cond_1
+
+    .line 13
+    .line 14
+    iget-object v3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->blockProfileController:Lcom/random/chat/app/data/controller/BlockProfileController;
+
+    .line 15
+    .line 16
+    invoke-virtual {v2}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 17
+    .line 18
+    .line 19
+    move-result-object v4
+
+    .line 20
+    invoke-virtual {v3, v4}, Lcom/random/chat/app/data/controller/BlockProfileController;->verifyBlocked(Ljava/lang/String;)Z
+
+    .line 21
+    .line 22
+    .line 23
+    move-result v3
+
+    .line 24
+    invoke-virtual {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->uploadBlocked()Ljava/util/Date;
+
+    .line 25
+    .line 26
+    .line 27
+    move-result-object v4
+
+    .line 28
+    iget-object v5, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 29
+    .line 30
+    invoke-virtual {v2}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object v2
+
+    .line 34
+    const/4 v6, 0x2
+
+    .line 35
+    invoke-virtual {v5, v2, v6}, Lcom/random/chat/app/data/controller/MessageController;->haveMessagesReceived(Ljava/lang/String;I)Z
+
+    .line 36
+    .line 37
+    .line 38
+    move-result v2
+
+    .line 39
+    if-nez v3, :cond_0
+
+    .line 40
+    .line 41
+    if-nez v4, :cond_0
+
+    .line 42
+    .line 43
+    if-eqz v2, :cond_0
+
+    .line 44
+    .line 45
+    const/4 v2, 0x1
+
+    .line 46
+    goto :goto_0
+
+    .line 47
+    :cond_0
+    const/4 v2, 0x0
+
+    .line 48
+    :goto_0
+    new-instance v3, Lcom/random/chat/app/ui/chat/SendImageEvent;
+
+    .line 49
+    .line 50
+    invoke-direct {v3, v2, v4, v0, p1}, Lcom/random/chat/app/ui/chat/SendImageEvent;-><init>(ZLjava/util/Date;ILcom/random/chat/app/ui/chat/FileShareObject;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 51
+    .line 52
+    .line 53
+    return-object v3
+
+    .line 54
+    :catch_0
+    move-exception p1
+
+    .line 55
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 56
+    .line 57
+    .line 58
+    :cond_1
+    new-instance p1, Lcom/random/chat/app/ui/chat/SendImageEvent;
+
+    .line 59
+    .line 60
+    const/4 v2, 0x0
+
+    .line 61
+    invoke-direct {p1, v1, v2, v0}, Lcom/random/chat/app/ui/chat/SendImageEvent;-><init>(ZLjava/util/Date;I)V
+
+    .line 62
+    .line 63
+    .line 64
+    return-object p1
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private synthetic lambda$verifyCanShare$28(Lcom/random/chat/app/ui/chat/SendImageEvent;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->sendImageEvent:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-void
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method public static synthetic m(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$launchDownloadAudio$36(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    return-void
+.end method
+
+.method public static synthetic n(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$changeAllowImages$19(Z)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic o(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$sendMessage$21(Lcom/random/chat/app/data/entity/MessageChat;)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method private onAddedMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 3
+
+    .line 1
+    :try_start_0
+    const-string v0, "ChatViewModel"
+
+    .line 2
+    .line 3
+    const-string v1, "onAddedMessage"
+
+    .line 4
+    .line 5
+    invoke-static {v0, v1}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->clone()Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 9
+    .line 10
+    .line 11
+    move-result-object p1
+
+    .line 12
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 13
+    .line 14
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 19
+    .line 20
+    if-eqz v0, :cond_5
+
+    .line 21
+    .line 22
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdTalk()Ljava/lang/String;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v1
+
+    .line 26
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v2
+
+    .line 30
+    invoke-static {v1, v2}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 31
+    .line 32
+    .line 33
+    move-result v1
+
+    .line 34
+    if-nez v1, :cond_0
+
+    .line 35
+    .line 36
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 37
+    .line 38
+    .line 39
+    move-result-object v1
+
+    .line 40
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdProfile()Ljava/lang/String;
+
+    .line 41
+    .line 42
+    .line 43
+    move-result-object v2
+
+    .line 44
+    invoke-static {v1, v2}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 45
+    .line 46
+    .line 47
+    move-result v1
+
+    .line 48
+    if-eqz v1, :cond_5
+
+    .line 49
+    .line 50
+    goto :goto_0
+
+    .line 51
+    :catch_0
+    move-exception p1
+
+    .line 52
+    goto/16 :goto_2
+
+    .line 53
+    .line 54
+    :cond_0
+    :goto_0
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getType()Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 55
+    .line 56
+    .line 57
+    move-result-object v1
+
+    .line 58
+    sget-object v2, Lcom/random/chat/app/data/entity/type/MessageType;->IMAGE:Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 59
+    .line 60
+    invoke-virtual {v1, v2}, Ljava/lang/Object;->equals(Ljava/lang/Object;)Z
+
+    .line 61
+    .line 62
+    .line 63
+    move-result v1
+
+    .line 64
+    if-nez v1, :cond_1
+
+    .line 65
+    .line 66
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getType()Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 67
+    .line 68
+    .line 69
+    move-result-object v1
+
+    .line 70
+    sget-object v2, Lcom/random/chat/app/data/entity/type/MessageType;->GIF:Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 71
+    .line 72
+    invoke-virtual {v1, v2}, Ljava/lang/Object;->equals(Ljava/lang/Object;)Z
+
+    .line 73
+    .line 74
+    .line 75
+    move-result v1
+
+    .line 76
+    if-eqz v1, :cond_2
+
+    .line 77
+    .line 78
+    :cond_1
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->isAllowImages()Z
+
+    .line 79
+    .line 80
+    .line 81
+    move-result v0
+
+    .line 82
+    if-nez v0, :cond_2
+
+    .line 83
+    .line 84
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isMine()Z
+
+    .line 85
+    .line 86
+    .line 87
+    move-result v0
+
+    .line 88
+    if-eqz v0, :cond_5
+
+    .line 89
+    .line 90
+    :cond_2
+    const/4 v0, 0x1
+
+    .line 91
+    iput-boolean v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->scrollBottom:Z
+
+    .line 92
+    .line 93
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 94
+    .line 95
+    invoke-interface {v1}, Ljava/util/List;->isEmpty()Z
+
+    .line 96
+    .line 97
+    .line 98
+    move-result v1
+
+    .line 99
+    if-eqz v1, :cond_3
+
+    .line 100
+    .line 101
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 102
+    .line 103
+    invoke-static {p1}, Ljava/util/Collections;->singletonList(Ljava/lang/Object;)Ljava/util/List;
+
+    .line 104
+    .line 105
+    .line 106
+    move-result-object p1
+
+    .line 107
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->divideMessageByDate(Ljava/util/List;)Ljava/util/List;
+
+    .line 108
+    .line 109
+    .line 110
+    move-result-object p1
+
+    .line 111
+    invoke-interface {v0, p1}, Ljava/util/List;->addAll(Ljava/util/Collection;)Z
+
+    .line 112
+    .line 113
+    .line 114
+    goto :goto_1
+
+    .line 115
+    :cond_3
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 116
+    .line 117
+    invoke-interface {v1}, Ljava/util/List;->size()I
+
+    .line 118
+    .line 119
+    .line 120
+    move-result v2
+
+    .line 121
+    sub-int/2addr v2, v0
+
+    .line 122
+    invoke-interface {v1, v2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    .line 123
+    .line 124
+    .line 125
+    move-result-object v0
+
+    .line 126
+    check-cast v0, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 127
+    .line 128
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 129
+    .line 130
+    .line 131
+    move-result-object v0
+
+    .line 132
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 133
+    .line 134
+    .line 135
+    move-result-object v1
+
+    .line 136
+    invoke-static {v0, v1}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 137
+    .line 138
+    .line 139
+    move-result v0
+
+    .line 140
+    if-nez v0, :cond_4
+
+    .line 141
+    .line 142
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 143
+    .line 144
+    invoke-interface {v0, p1}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+
+    .line 145
+    .line 146
+    .line 147
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 148
+    .line 149
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->divideMessageByDate(Ljava/util/List;)Ljava/util/List;
+
+    .line 150
+    .line 151
+    .line 152
+    move-result-object p1
+
+    .line 153
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 154
+    .line 155
+    invoke-interface {v0}, Ljava/util/List;->clear()V
+
+    .line 156
+    .line 157
+    .line 158
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 159
+    .line 160
+    invoke-interface {v0, p1}, Ljava/util/List;->addAll(Ljava/util/Collection;)Z
+
+    .line 161
+    .line 162
+    .line 163
+    :cond_4
+    :goto_1
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 164
+    .line 165
+    new-instance v0, Ljava/util/ArrayList;
+
+    .line 166
+    .line 167
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 168
+    .line 169
+    invoke-direct {v0, v1}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 170
+    .line 171
+    .line 172
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 173
+    .line 174
+    .line 175
+    goto :goto_3
+
+    .line 176
+    :goto_2
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 177
+    .line 178
+    .line 179
+    :cond_5
+    :goto_3
+    return-void
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method private onPresence(Lcom/random/chat/app/data/entity/Presence;)V
+    .locals 2
+
+    .line 1
+    const-string v0, "ChatViewModel"
+
+    .line 2
+    .line 3
+    const-string v1, "onPresence"
+
+    .line 4
+    .line 5
+    invoke-static {v0, v1}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 9
+    .line 10
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 15
+    .line 16
+    if-eqz v0, :cond_0
+
+    .line 17
+    .line 18
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/Presence;->getId()Ljava/lang/String;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v1
+
+    .line 22
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v0
+
+    .line 26
+    invoke-static {v1, v0}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 27
+    .line 28
+    .line 29
+    move-result v0
+
+    .line 30
+    if-eqz v0, :cond_0
+
+    .line 31
+    .line 32
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presence:Landroidx/lifecycle/MutableLiveData;
+
+    .line 33
+    .line 34
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 35
+    .line 36
+    .line 37
+    goto :goto_1
+
+    .line 38
+    :catch_0
+    move-exception p1
+
+    .line 39
+    goto :goto_0
+
+    .line 40
+    :cond_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presenceController:Lcom/random/chat/app/data/controller/PresenceController;
+
+    .line 41
+    .line 42
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/Presence;->getId()Ljava/lang/String;
+
+    .line 43
+    .line 44
+    .line 45
+    move-result-object p1
+
+    .line 46
+    invoke-virtual {v0, p1}, Lcom/random/chat/app/data/controller/PresenceController;->unsubscribePresence(Ljava/lang/String;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 47
+    .line 48
+    .line 49
+    goto :goto_1
+
+    .line 50
+    :goto_0
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 51
+    .line 52
+    .line 53
+    :goto_1
+    return-void
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method private onUpdatedMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 4
+
+    .line 1
+    :try_start_0
+    const-string v0, "ChatViewModel"
+
+    .line 2
+    .line 3
+    const-string v1, "onUpdatedMessage"
+
+    .line 4
+    .line 5
+    invoke-static {v0, v1}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->clone()Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 9
+    .line 10
+    .line 11
+    move-result-object p1
+
+    .line 12
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 13
+    .line 14
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 19
+    .line 20
+    if-eqz v0, :cond_1
+
+    .line 21
+    .line 22
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v0
+
+    .line 26
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdTalk()Ljava/lang/String;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-static {v0, v1}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 31
+    .line 32
+    .line 33
+    move-result v0
+
+    .line 34
+    if-eqz v0, :cond_1
+
+    .line 35
+    .line 36
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 37
+    .line 38
+    invoke-interface {v0}, Ljava/util/List;->size()I
+
+    .line 39
+    .line 40
+    .line 41
+    move-result v0
+
+    .line 42
+    add-int/lit8 v0, v0, -0x1
+
+    .line 43
+    .line 44
+    :goto_0
+    if-ltz v0, :cond_1
+
+    .line 45
+    .line 46
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 47
+    .line 48
+    invoke-interface {v1, v0}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    .line 49
+    .line 50
+    .line 51
+    move-result-object v1
+
+    .line 52
+    check-cast v1, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 53
+    .line 54
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 55
+    .line 56
+    .line 57
+    move-result-object v2
+
+    .line 58
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 59
+    .line 60
+    .line 61
+    move-result-object v3
+
+    .line 62
+    invoke-static {v2, v3}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 63
+    .line 64
+    .line 65
+    move-result v2
+
+    .line 66
+    if-eqz v2, :cond_0
+
+    .line 67
+    .line 68
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageChat;->isPlaying()Z
+
+    .line 69
+    .line 70
+    .line 71
+    move-result v2
+
+    .line 72
+    invoke-virtual {p1, v2}, Lcom/random/chat/app/data/entity/MessageChat;->setPlaying(Z)V
+
+    .line 73
+    .line 74
+    .line 75
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageChat;->getStartTime()D
+
+    .line 76
+    .line 77
+    .line 78
+    move-result-wide v1
+
+    .line 79
+    invoke-virtual {p1, v1, v2}, Lcom/random/chat/app/data/entity/MessageChat;->setStartTime(D)V
+
+    .line 80
+    .line 81
+    .line 82
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getStatus()Lcom/random/chat/app/data/entity/type/StatusType;
+
+    .line 83
+    .line 84
+    .line 85
+    move-result-object v1
+
+    .line 86
+    invoke-virtual {p1, v1}, Lcom/random/chat/app/data/entity/MessageChat;->setStatus(Lcom/random/chat/app/data/entity/type/StatusType;)V
+
+    .line 87
+    .line 88
+    .line 89
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isStarted()Z
+
+    .line 90
+    .line 91
+    .line 92
+    move-result v1
+
+    .line 93
+    invoke-virtual {p1, v1}, Lcom/random/chat/app/data/entity/MessageChat;->setStarted(Z)V
+
+    .line 94
+    .line 95
+    .line 96
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFailed()Z
+
+    .line 97
+    .line 98
+    .line 99
+    move-result v1
+
+    .line 100
+    invoke-virtual {p1, v1}, Lcom/random/chat/app/data/entity/MessageChat;->setFailed(Z)V
+
+    .line 101
+    .line 102
+    .line 103
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFinished()Z
+
+    .line 104
+    .line 105
+    .line 106
+    move-result v1
+
+    .line 107
+    invoke-virtual {p1, v1}, Lcom/random/chat/app/data/entity/MessageChat;->setFinished(Z)V
+
+    .line 108
+    .line 109
+    .line 110
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 111
+    .line 112
+    invoke-interface {v1, v0, p1}, Ljava/util/List;->set(ILjava/lang/Object;)Ljava/lang/Object;
+
+    .line 113
+    .line 114
+    .line 115
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 116
+    .line 117
+    new-instance v0, Ljava/util/ArrayList;
+
+    .line 118
+    .line 119
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 120
+    .line 121
+    invoke-direct {v0, v1}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 122
+    .line 123
+    .line 124
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 125
+    .line 126
+    .line 127
+    goto :goto_2
+
+    .line 128
+    :catch_0
+    move-exception p1
+
+    .line 129
+    goto :goto_1
+
+    .line 130
+    :cond_0
+    add-int/lit8 v0, v0, -0x1
+
+    .line 131
+    .line 132
+    goto :goto_0
+
+    .line 133
+    :goto_1
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 134
+    .line 135
+    .line 136
+    :cond_1
+    :goto_2
+    return-void
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method private onUpdatedTalk(Lcom/random/chat/app/data/entity/TalkChat;)V
+    .locals 2
+
+    .line 1
+    const-string v0, "ChatViewModel"
+
+    .line 2
+    .line 3
+    const-string v1, "onUpdatedTalk"
+
+    .line 4
+    .line 5
+    invoke-static {v0, v1}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 9
+    .line 10
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 15
+    .line 16
+    if-eqz v0, :cond_1
+
+    .line 17
+    .line 18
+    if-eqz p1, :cond_1
+
+    .line 19
+    .line 20
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 21
+    .line 22
+    .line 23
+    move-result-object v1
+
+    .line 24
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 25
+    .line 26
+    .line 27
+    move-result-object v0
+
+    .line 28
+    invoke-static {v1, v0}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 29
+    .line 30
+    .line 31
+    move-result v0
+
+    .line 32
+    if-eqz v0, :cond_1
+
+    .line 33
+    .line 34
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 35
+    .line 36
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 37
+    .line 38
+    .line 39
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->requestSnackAllowImages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 40
+    .line 41
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 42
+    .line 43
+    .line 44
+    move-result-object v0
+
+    .line 45
+    check-cast v0, Ljava/lang/Boolean;
+
+    .line 46
+    .line 47
+    if-eqz v0, :cond_0
+
+    .line 48
+    .line 49
+    invoke-virtual {v0}, Ljava/lang/Boolean;->booleanValue()Z
+
+    .line 50
+    .line 51
+    .line 52
+    move-result v0
+
+    .line 53
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->isVerifyImages()Z
+
+    .line 54
+    .line 55
+    .line 56
+    move-result v1
+
+    .line 57
+    if-eq v0, v1, :cond_1
+
+    .line 58
+    .line 59
+    goto :goto_0
+
+    .line 60
+    :catch_0
+    move-exception p1
+
+    .line 61
+    goto :goto_1
+
+    .line 62
+    :cond_0
+    :goto_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->requestSnackAllowImages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 63
+    .line 64
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/TalkChat;->isVerifyImages()Z
+
+    .line 65
+    .line 66
+    .line 67
+    move-result p1
+
+    .line 68
+    invoke-static {p1}, Ljava/lang/Boolean;->valueOf(Z)Ljava/lang/Boolean;
+
+    .line 69
+    .line 70
+    .line 71
+    move-result-object p1
+
+    .line 72
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 73
+    .line 74
+    .line 75
+    goto :goto_2
+
+    .line 76
+    :goto_1
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 77
+    .line 78
+    .line 79
+    :cond_1
+    :goto_2
+    return-void
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method public static synthetic p(Lcom/random/chat/app/ui/chat/ChatViewModel;I)Lcom/random/chat/app/ui/chat/SendImageEvent;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$verifyCanSend$25(I)Lcom/random/chat/app/ui/chat/SendImageEvent;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic q(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/TalkChat;)Lcom/random/chat/app/data/entity/MessageChat;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2, p3, p4}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$uploadImage$15(Lcom/random/chat/app/data/entity/MessageChat;Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/TalkChat;)Lcom/random/chat/app/data/entity/MessageChat;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic r(Lcom/random/chat/app/ui/chat/ChatViewModel;ZZ)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$delete$7(ZZ)Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic s(Lcom/random/chat/app/ui/chat/ChatViewModel;)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$markRead$11()Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic t(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$uploadImage$16(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    return-void
+.end method
+
+.method public static synthetic u(Lcom/random/chat/app/ui/chat/ChatViewModel;)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$acceptImages$33()Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic v(Lcom/random/chat/app/ui/chat/ChatViewModel;)Ljava/lang/Boolean;
+    .locals 0
+
+    .line 1
+    invoke-direct {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$startRecord$41()Ljava/lang/Boolean;
+
+    move-result-object p0
+
+    return-object p0
+.end method
+
+.method public static synthetic w(Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-static {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$cleanMessagesChat$30(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic x(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;)V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0, p1, p2}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$stopRecord$45(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/ui/chat/ChatViewModel$UploadAudio;)V
+
+    return-void
+.end method
+
+.method public static synthetic y(Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-static {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$updateFavorite$32(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+.method public static synthetic z(Ljava/lang/Boolean;)V
+    .locals 0
+
+    .line 1
+    invoke-static {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->lambda$report$4(Ljava/lang/Boolean;)V
+
+    return-void
+.end method
+
+
+# virtual methods
+.method acceptImages()V
+    .locals 2
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/W0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/W0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object v0
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v1
+
+    .line 14
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v1
+
+    .line 18
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v1
+
+    .line 22
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v0
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object v0
+
+    .line 34
+    new-instance v1, Lcom/random/chat/app/ui/chat/X0;
+
+    .line 35
+    .line 36
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/X0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object v0
+
+    .line 43
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method block(Z)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/D0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/D0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/E0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/E0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method changeAllowImages(Z)V
+    .locals 2
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/S0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/S0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object v0
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v1
+
+    .line 14
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v1
+
+    .line 18
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v1
+
+    .line 22
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v0
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object v0
+
+    .line 34
+    new-instance v1, Lcom/random/chat/app/ui/chat/T0;
+
+    .line 35
+    .line 36
+    invoke-direct {v1, p0, p1}, Lcom/random/chat/app/ui/chat/T0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method changeBackground(Ljava/lang/String;)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/z0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/z0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/lang/String;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/A0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/A0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method cleanMessagesChat(Z)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/s0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/s0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/schedulers/Schedulers;->d()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/t0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0}, Lcom/random/chat/app/ui/chat/t0;-><init>()V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method delete(ZZ)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/Y0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1, p2}, Lcom/random/chat/app/ui/chat/Y0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;ZZ)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object p2
+
+    .line 14
+    invoke-virtual {p2}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object p2
+
+    .line 18
+    invoke-static {p2}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object p2
+
+    .line 22
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object p2
+
+    .line 30
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance p2, Lcom/random/chat/app/ui/chat/Z;
+
+    .line 35
+    .line 36
+    invoke-direct {p2, p0}, Lcom/random/chat/app/ui/chat/Z;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {p2, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+    .line 68
+    .line 69
+    .line 70
+    .line 71
+    .line 72
+    .line 73
+    .line 74
+    .line 75
+    .line 76
+    .line 77
+    .line 78
+    .line 79
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+    .line 221
+    .line 222
+    .line 223
+    .line 224
+    .line 225
+    .line 226
+    .line 227
+    .line 228
+    .line 229
+    .line 230
+.end method
+
+.method deleteSelectedMessages(Ljava/util/List;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "(",
+            "Ljava/util/List<",
+            "Ljava/lang/Integer;",
+            ">;)V"
+        }
+    .end annotation
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/x0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/x0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Ljava/util/List;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/y0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/y0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method getSendMessageTextWatcher()Landroid/text/TextWatcher;
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/ChatViewModel$1;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/ChatViewModel$1;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 4
+    .line 5
+    .line 6
+    return-object v0
+    .line 7
+    .line 8
+    .line 9
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+.end method
+
+.method gifShareFromKeyboard(Landroid/net/Uri;)V
+    .locals 2
+
+    .line 1
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    .line 2
+    .line 3
+    invoke-direct {v0}, Ljava/lang/StringBuilder;-><init>()V
+
+    .line 4
+    .line 5
+    .line 6
+    const-string v1, "Share gif:"
+
+    .line 7
+    .line 8
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 9
+    .line 10
+    .line 11
+    invoke-virtual {p1}, Landroid/net/Uri;->toString()Ljava/lang/String;
+
+    .line 12
+    .line 13
+    .line 14
+    move-result-object v1
+
+    .line 15
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 16
+    .line 17
+    .line 18
+    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    const-string v1, "ChatViewModel"
+
+    .line 23
+    .line 24
+    invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 25
+    .line 26
+    .line 27
+    new-instance v0, Lcom/random/chat/app/ui/chat/FileShareObject;
+
+    .line 28
+    .line 29
+    const-string v1, "image/gif"
+
+    .line 30
+    .line 31
+    invoke-direct {v0, p1, v1}, Lcom/random/chat/app/ui/chat/FileShareObject;-><init>(Landroid/net/Uri;Ljava/lang/String;)V
+
+    .line 32
+    .line 33
+    .line 34
+    invoke-virtual {p0, v0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->verifyCanShare(Lcom/random/chat/app/ui/chat/FileShareObject;)V
+
+    .line 35
+    .line 36
+    .line 37
+    return-void
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method handleCrop(Landroid/content/Intent;)V
+    .locals 1
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    new-instance v0, Lcom/random/chat/app/ui/chat/B0;
+
+    .line 12
+    .line 13
+    invoke-direct {v0, p1}, Lcom/random/chat/app/ui/chat/B0;-><init>(Landroid/content/Intent;)V
+
+    .line 14
+    .line 15
+    .line 16
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 17
+    .line 18
+    .line 19
+    move-result-object p1
+
+    .line 20
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 21
+    .line 22
+    .line 23
+    move-result-object v0
+
+    .line 24
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 25
+    .line 26
+    .line 27
+    move-result-object v0
+
+    .line 28
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 29
+    .line 30
+    .line 31
+    move-result-object v0
+
+    .line 32
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 33
+    .line 34
+    .line 35
+    move-result-object p1
+
+    .line 36
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 37
+    .line 38
+    .line 39
+    move-result-object v0
+
+    .line 40
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 41
+    .line 42
+    .line 43
+    move-result-object p1
+
+    .line 44
+    new-instance v0, Lcom/random/chat/app/ui/chat/C0;
+
+    .line 45
+    .line 46
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/C0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 47
+    .line 48
+    .line 49
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 50
+    .line 51
+    .line 52
+    move-result-object p1
+
+    .line 53
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 54
+    .line 55
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 56
+    .line 57
+    .line 58
+    :cond_0
+    return-void
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method imageShareFromKeyboard(Landroid/net/Uri;)V
+    .locals 2
+
+    .line 1
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    .line 2
+    .line 3
+    invoke-direct {v0}, Ljava/lang/StringBuilder;-><init>()V
+
+    .line 4
+    .line 5
+    .line 6
+    const-string v1, "Share image:"
+
+    .line 7
+    .line 8
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 9
+    .line 10
+    .line 11
+    invoke-virtual {p1}, Landroid/net/Uri;->toString()Ljava/lang/String;
+
+    .line 12
+    .line 13
+    .line 14
+    move-result-object v1
+
+    .line 15
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    .line 16
+    .line 17
+    .line 18
+    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    const-string v1, "ChatViewModel"
+
+    .line 23
+    .line 24
+    invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 25
+    .line 26
+    .line 27
+    new-instance v0, Lcom/random/chat/app/ui/chat/FileShareObject;
+
+    .line 28
+    .line 29
+    const-string v1, "image/png"
+
+    .line 30
+    .line 31
+    invoke-direct {v0, p1, v1}, Lcom/random/chat/app/ui/chat/FileShareObject;-><init>(Landroid/net/Uri;Ljava/lang/String;)V
+
+    .line 32
+    .line 33
+    .line 34
+    invoke-virtual {p0, v0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->verifyCanShare(Lcom/random/chat/app/ui/chat/FileShareObject;)V
+
+    .line 35
+    .line 36
+    .line 37
+    return-void
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method initialize(Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/Presence;Z)V
+    .locals 1
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0, p1}, Landroidx/lifecycle/MutableLiveData;->o(Ljava/lang/Object;)V
+
+    .line 4
+    .line 5
+    .line 6
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presence:Landroidx/lifecycle/MutableLiveData;
+
+    .line 7
+    .line 8
+    invoke-virtual {v0, p2}, Landroidx/lifecycle/MutableLiveData;->o(Ljava/lang/Object;)V
+
+    .line 9
+    .line 10
+    .line 11
+    iput-boolean p3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->newChat:Z
+
+    .line 12
+    .line 13
+    new-instance p2, Lcom/random/chat/app/ui/chat/K0;
+
+    .line 14
+    .line 15
+    invoke-direct {p2, p0, p1}, Lcom/random/chat/app/ui/chat/K0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 16
+    .line 17
+    .line 18
+    invoke-static {p2}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object p1
+
+    .line 22
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p2
+
+    .line 26
+    invoke-virtual {p2}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutorComputation()Ljava/util/concurrent/ExecutorService;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object p2
+
+    .line 30
+    invoke-static {p2}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p2
+
+    .line 34
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 35
+    .line 36
+    .line 37
+    move-result-object p1
+
+    .line 38
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 39
+    .line 40
+    .line 41
+    move-result-object p2
+
+    .line 42
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 43
+    .line 44
+    .line 45
+    move-result-object p1
+
+    .line 46
+    new-instance p2, Lcom/random/chat/app/ui/chat/L0;
+
+    .line 47
+    .line 48
+    invoke-direct {p2, p0}, Lcom/random/chat/app/ui/chat/L0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 49
+    .line 50
+    .line 51
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 52
+    .line 53
+    .line 54
+    move-result-object p1
+
+    .line 55
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 56
+    .line 57
+    invoke-virtual {p2, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 58
+    .line 59
+    .line 60
+    return-void
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+    .line 68
+    .line 69
+    .line 70
+    .line 71
+    .line 72
+    .line 73
+    .line 74
+    .line 75
+    .line 76
+    .line 77
+    .line 78
+    .line 79
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+.end method
+
+.method launchDownloadAudio(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 2
+
+    .line 1
+    const-string v0, "ChatViewModel"
+
+    .line 2
+    .line 3
+    const-string v1, "launchDownloadAudio"
+
+    .line 4
+    .line 5
+    invoke-static {v0, v1}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isMine()Z
+
+    .line 9
+    .line 10
+    .line 11
+    move-result v0
+
+    .line 12
+    if-eqz v0, :cond_0
+
+    .line 13
+    .line 14
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 15
+    .line 16
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 17
+    .line 18
+    .line 19
+    move-result-object v0
+
+    .line 20
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 21
+    .line 22
+    if-eqz v0, :cond_1
+
+    .line 23
+    .line 24
+    new-instance v1, Lcom/random/chat/app/ui/chat/G0;
+
+    .line 25
+    .line 26
+    invoke-direct {v1, p0, v0, p1}, Lcom/random/chat/app/ui/chat/G0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 27
+    .line 28
+    .line 29
+    invoke-static {v1}, Lcom/random/chat/app/util/SingletonExecutor;->executeSocket(Ljava/lang/Runnable;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 30
+    .line 31
+    .line 32
+    goto :goto_0
+
+    .line 33
+    :catch_0
+    move-exception p1
+
+    .line 34
+    const-string v0, "AudioHolder"
+
+    .line 35
+    .line 36
+    invoke-virtual {p1}, Ljava/lang/Throwable;->getMessage()Ljava/lang/String;
+
+    .line 37
+    .line 38
+    .line 39
+    move-result-object v1
+
+    .line 40
+    invoke-static {v0, v1, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 41
+    .line 42
+    .line 43
+    goto :goto_0
+
+    .line 44
+    :cond_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 45
+    .line 46
+    invoke-virtual {v0, p1}, Lcom/random/chat/app/data/controller/MessageController;->startDownloadMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 47
+    .line 48
+    .line 49
+    :cond_1
+    :goto_0
+    return-void
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method launchDownloadImage(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 14
+
+    .line 1
+    const-string v0, "launchDownloadImage"
+
+    .line 2
+    .line 3
+    const-string v1, "ChatViewModel"
+
+    .line 4
+    .line 5
+    invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 6
+    .line 7
+    .line 8
+    :try_start_0
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getType()Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 9
+    .line 10
+    .line 11
+    move-result-object v0
+
+    .line 12
+    sget-object v2, Lcom/random/chat/app/data/entity/type/MessageType;->IMAGE:Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 13
+    .line 14
+    invoke-virtual {v0, v2}, Ljava/lang/Object;->equals(Ljava/lang/Object;)Z
+
+    .line 15
+    .line 16
+    .line 17
+    move-result v0
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 18
+    const-string v2, "!img.isStarted() || img.isFailed()"
+
+    .line 19
+    .line 20
+    const-string v3, "img.isStarted"
+
+    .line 21
+    .line 22
+    const-string v4, "http"
+
+    .line 23
+    .line 24
+    const-string v5, "!clicked.isMine"
+
+    .line 25
+    .line 26
+    const-string v6, "img.isStarted()"
+
+    .line 27
+    .line 28
+    const-string v7, "img.isFailed()"
+
+    .line 29
+    .line 30
+    const-string v8, "clicked.isMine"
+
+    .line 31
+    .line 32
+    const-string v9, "img.isFinished() && !img.isFailed()"
+
+    .line 33
+    .line 34
+    const-string v10, "vish"
+
+    .line 35
+    .line 36
+    if-eqz v0, :cond_a
+
+    .line 37
+    .line 38
+    :try_start_1
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 39
+    .line 40
+    .line 41
+    move-result-object v0
+
+    .line 42
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->isEmpty(Ljava/lang/String;)Z
+
+    .line 43
+    .line 44
+    .line 45
+    move-result v0
+
+    .line 46
+    if-nez v0, :cond_9
+
+    .line 47
+    .line 48
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isMine()Z
+
+    .line 49
+    .line 50
+    .line 51
+    move-result v0
+    :try_end_1
+    .catch Ljava/lang/Exception; {:try_start_1 .. :try_end_1} :catch_0
+
+    .line 52
+    const/4 v11, 0x0
+
+    .line 53
+    const-string v12, "file"
+
+    .line 54
+    .line 55
+    const-class v13, Lcom/random/chat/app/ui/SingleTouchImageViewActivity;
+
+    .line 56
+    .line 57
+    if-eqz v0, :cond_3
+
+    .line 58
+    .line 59
+    :try_start_2
+    invoke-static {v1, v8}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 60
+    .line 61
+    .line 62
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFinished()Z
+
+    .line 63
+    .line 64
+    .line 65
+    move-result v0
+
+    .line 66
+    if-eqz v0, :cond_0
+
+    .line 67
+    .line 68
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFailed()Z
+
+    .line 69
+    .line 70
+    .line 71
+    move-result v0
+
+    .line 72
+    if-nez v0, :cond_0
+
+    .line 73
+    .line 74
+    invoke-static {v1, v9}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 75
+    .line 76
+    .line 77
+    new-instance v0, Landroid/content/Intent;
+
+    .line 78
+    .line 79
+    invoke-virtual {p0}, Landroidx/lifecycle/AndroidViewModel;->getApplication()Landroid/app/Application;
+
+    .line 80
+    .line 81
+    .line 82
+    move-result-object v1
+
+    .line 83
+    invoke-direct {v0, v1, v13}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
+
+    .line 84
+    .line 85
+    .line 86
+    new-instance v1, Landroid/os/Bundle;
+
+    .line 87
+    .line 88
+    invoke-direct {v1}, Landroid/os/Bundle;-><init>()V
+
+    .line 89
+    .line 90
+    .line 91
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 92
+    .line 93
+    .line 94
+    move-result-object p1
+
+    .line 95
+    invoke-virtual {v1, v12, p1}, Landroid/os/BaseBundle;->putString(Ljava/lang/String;Ljava/lang/String;)V
+
+    .line 96
+    .line 97
+    .line 98
+    invoke-virtual {v0, v1}, Landroid/content/Intent;->putExtras(Landroid/os/Bundle;)Landroid/content/Intent;
+
+    .line 99
+    .line 100
+    .line 101
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->nextActivity:Landroidx/lifecycle/MutableLiveData;
+
+    .line 102
+    .line 103
+    new-instance v1, Lcom/random/chat/app/ui/chat/NextActivity;
+
+    .line 104
+    .line 105
+    invoke-direct {v1, v0, v11}, Lcom/random/chat/app/ui/chat/NextActivity;-><init>(Landroid/content/Intent;Z)V
+
+    .line 106
+    .line 107
+    .line 108
+    invoke-virtual {p1, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 109
+    .line 110
+    .line 111
+    goto/16 :goto_3
+
+    .line 112
+    .line 113
+    :catch_0
+    move-exception p1
+
+    .line 114
+    goto/16 :goto_2
+
+    .line 115
+    .line 116
+    :cond_0
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFailed()Z
+
+    .line 117
+    .line 118
+    .line 119
+    move-result v0
+
+    .line 120
+    if-eqz v0, :cond_1
+
+    .line 121
+    .line 122
+    invoke-static {v1, v7}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 123
+    .line 124
+    .line 125
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 126
+    .line 127
+    .line 128
+    move-result-object v0
+
+    .line 129
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getType()Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 130
+    .line 131
+    .line 132
+    move-result-object v1
+
+    .line 133
+    invoke-virtual {p0, v0, v1, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->uploadImage(Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 134
+    .line 135
+    .line 136
+    goto/16 :goto_3
+
+    .line 137
+    .line 138
+    :cond_1
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isStarted()Z
+
+    .line 139
+    .line 140
+    .line 141
+    move-result v0
+
+    .line 142
+    if-eqz v0, :cond_2
+
+    .line 143
+    .line 144
+    invoke-static {v1, v6}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 145
+    .line 146
+    .line 147
+    goto/16 :goto_3
+
+    .line 148
+    .line 149
+    :cond_2
+    invoke-static {v1, v10}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 150
+    .line 151
+    .line 152
+    new-instance v0, Landroid/content/Intent;
+
+    .line 153
+    .line 154
+    invoke-virtual {p0}, Landroidx/lifecycle/AndroidViewModel;->getApplication()Landroid/app/Application;
+
+    .line 155
+    .line 156
+    .line 157
+    move-result-object v1
+
+    .line 158
+    invoke-direct {v0, v1, v13}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
+
+    .line 159
+    .line 160
+    .line 161
+    new-instance v1, Landroid/os/Bundle;
+
+    .line 162
+    .line 163
+    invoke-direct {v1}, Landroid/os/Bundle;-><init>()V
+
+    .line 164
+    .line 165
+    .line 166
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 167
+    .line 168
+    .line 169
+    move-result-object p1
+
+    .line 170
+    invoke-virtual {v1, v12, p1}, Landroid/os/BaseBundle;->putString(Ljava/lang/String;Ljava/lang/String;)V
+
+    .line 171
+    .line 172
+    .line 173
+    invoke-virtual {v0, v1}, Landroid/content/Intent;->putExtras(Landroid/os/Bundle;)Landroid/content/Intent;
+
+    .line 174
+    .line 175
+    .line 176
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->nextActivity:Landroidx/lifecycle/MutableLiveData;
+
+    .line 177
+    .line 178
+    new-instance v1, Lcom/random/chat/app/ui/chat/NextActivity;
+
+    .line 179
+    .line 180
+    invoke-direct {v1, v0, v11}, Lcom/random/chat/app/ui/chat/NextActivity;-><init>(Landroid/content/Intent;Z)V
+
+    .line 181
+    .line 182
+    .line 183
+    invoke-virtual {p1, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 184
+    .line 185
+    .line 186
+    goto/16 :goto_3
+
+    .line 187
+    .line 188
+    :cond_3
+    invoke-static {v1, v5}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 189
+    .line 190
+    .line 191
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 192
+    .line 193
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdTalk()Ljava/lang/String;
+
+    .line 194
+    .line 195
+    .line 196
+    move-result-object v5
+
+    .line 197
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 198
+    .line 199
+    .line 200
+    move-result-object v6
+
+    .line 201
+    invoke-virtual {v0, v5, v6}, Lcom/random/chat/app/data/controller/MessageController;->getMessage(Ljava/lang/String;Ljava/lang/String;)Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 202
+    .line 203
+    .line 204
+    move-result-object v0
+
+    .line 205
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/MessageChat;->clone()Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 206
+    .line 207
+    .line 208
+    move-result-object v0
+
+    .line 209
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 210
+    .line 211
+    .line 212
+    move-result-object v5
+
+    .line 213
+    invoke-virtual {p1, v5}, Lcom/random/chat/app/data/entity/MessageChat;->setUrl(Ljava/lang/String;)V
+
+    .line 214
+    .line 215
+    .line 216
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/MessageChat;->getUrlThumb()Ljava/lang/String;
+
+    .line 217
+    .line 218
+    .line 219
+    move-result-object v0
+
+    .line 220
+    invoke-virtual {p1, v0}, Lcom/random/chat/app/data/entity/MessageChat;->setUrlThumb(Ljava/lang/String;)V
+
+    .line 221
+    .line 222
+    .line 223
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 224
+    .line 225
+    .line 226
+    move-result-object v0
+
+    .line 227
+    invoke-virtual {v0, v4}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+
+    .line 228
+    .line 229
+    .line 230
+    move-result v0
+
+    .line 231
+    if-nez v0, :cond_5
+
+    .line 232
+    .line 233
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 234
+    .line 235
+    .line 236
+    move-result-object v0
+
+    .line 237
+    const-string v4, "/"
+
+    .line 238
+    .line 239
+    invoke-virtual {v0, v4}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+
+    .line 240
+    .line 241
+    .line 242
+    move-result v0
+
+    .line 243
+    if-nez v0, :cond_4
+
+    .line 244
+    .line 245
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 246
+    .line 247
+    .line 248
+    move-result-object v0
+
+    .line 249
+    const-string v4, "\\/"
+
+    .line 250
+    .line 251
+    invoke-virtual {v0, v4}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+
+    .line 252
+    .line 253
+    .line 254
+    move-result v0
+
+    .line 255
+    if-eqz v0, :cond_5
+
+    .line 256
+    .line 257
+    :cond_4
+    new-instance v0, Landroid/content/Intent;
+
+    .line 258
+    .line 259
+    invoke-virtual {p0}, Landroidx/lifecycle/AndroidViewModel;->getApplication()Landroid/app/Application;
+
+    .line 260
+    .line 261
+    .line 262
+    move-result-object v1
+
+    .line 263
+    invoke-direct {v0, v1, v13}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
+
+    .line 264
+    .line 265
+    .line 266
+    new-instance v1, Landroid/os/Bundle;
+
+    .line 267
+    .line 268
+    invoke-direct {v1}, Landroid/os/Bundle;-><init>()V
+
+    .line 269
+    .line 270
+    .line 271
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 272
+    .line 273
+    .line 274
+    move-result-object p1
+
+    .line 275
+    invoke-virtual {v1, v12, p1}, Landroid/os/BaseBundle;->putString(Ljava/lang/String;Ljava/lang/String;)V
+
+    .line 276
+    .line 277
+    .line 278
+    invoke-virtual {v0, v1}, Landroid/content/Intent;->putExtras(Landroid/os/Bundle;)Landroid/content/Intent;
+
+    .line 279
+    .line 280
+    .line 281
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->nextActivity:Landroidx/lifecycle/MutableLiveData;
+
+    .line 282
+    .line 283
+    new-instance v1, Lcom/random/chat/app/ui/chat/NextActivity;
+
+    .line 284
+    .line 285
+    invoke-direct {v1, v0, v11}, Lcom/random/chat/app/ui/chat/NextActivity;-><init>(Landroid/content/Intent;Z)V
+
+    .line 286
+    .line 287
+    .line 288
+    invoke-virtual {p1, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 289
+    .line 290
+    .line 291
+    goto/16 :goto_3
+
+    .line 292
+    .line 293
+    :cond_5
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isStarted()Z
+
+    .line 294
+    .line 295
+    .line 296
+    move-result v0
+
+    .line 297
+    if-eqz v0, :cond_8
+
+    .line 298
+    .line 299
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFailed()Z
+
+    .line 300
+    .line 301
+    .line 302
+    move-result v0
+
+    .line 303
+    if-eqz v0, :cond_6
+
+    .line 304
+    .line 305
+    goto :goto_0
+
+    .line 306
+    :cond_6
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isStarted()Z
+
+    .line 307
+    .line 308
+    .line 309
+    move-result v0
+
+    .line 310
+    if-eqz v0, :cond_7
+
+    .line 311
+    .line 312
+    invoke-static {v1, v3}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 313
+    .line 314
+    .line 315
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 316
+    .line 317
+    invoke-virtual {v0, p1}, Lcom/random/chat/app/data/controller/MessageController;->stopDownloadMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 318
+    .line 319
+    .line 320
+    goto/16 :goto_3
+
+    .line 321
+    .line 322
+    :cond_7
+    invoke-static {v1, v10}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 323
+    .line 324
+    .line 325
+    goto/16 :goto_3
+
+    .line 326
+    .line 327
+    :cond_8
+    :goto_0
+    invoke-static {v1, v2}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 328
+    .line 329
+    .line 330
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 331
+    .line 332
+    invoke-virtual {v0, p1}, Lcom/random/chat/app/data/controller/MessageController;->startDownloadMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 333
+    .line 334
+    .line 335
+    goto/16 :goto_3
+
+    .line 336
+    .line 337
+    :cond_9
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->onError:Landroidx/lifecycle/MutableLiveData;
+
+    .line 338
+    .line 339
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 340
+    .line 341
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 342
+    .line 343
+    .line 344
+    goto/16 :goto_3
+
+    .line 345
+    .line 346
+    :cond_a
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getType()Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 347
+    .line 348
+    .line 349
+    move-result-object v0
+
+    .line 350
+    sget-object v11, Lcom/random/chat/app/data/entity/type/MessageType;->GIF:Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 351
+    .line 352
+    invoke-virtual {v0, v11}, Ljava/lang/Object;->equals(Ljava/lang/Object;)Z
+
+    .line 353
+    .line 354
+    .line 355
+    move-result v0
+
+    .line 356
+    if-eqz v0, :cond_14
+
+    .line 357
+    .line 358
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 359
+    .line 360
+    .line 361
+    move-result-object v0
+
+    .line 362
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->isEmpty(Ljava/lang/String;)Z
+
+    .line 363
+    .line 364
+    .line 365
+    move-result v0
+
+    .line 366
+    if-nez v0, :cond_13
+
+    .line 367
+    .line 368
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isMine()Z
+
+    .line 369
+    .line 370
+    .line 371
+    move-result v0
+
+    .line 372
+    if-eqz v0, :cond_e
+
+    .line 373
+    .line 374
+    invoke-static {v1, v8}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 375
+    .line 376
+    .line 377
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFinished()Z
+
+    .line 378
+    .line 379
+    .line 380
+    move-result v0
+
+    .line 381
+    if-eqz v0, :cond_b
+
+    .line 382
+    .line 383
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFailed()Z
+
+    .line 384
+    .line 385
+    .line 386
+    move-result v0
+
+    .line 387
+    if-nez v0, :cond_b
+
+    .line 388
+    .line 389
+    invoke-static {v1, v9}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 390
+    .line 391
+    .line 392
+    goto/16 :goto_3
+
+    .line 393
+    .line 394
+    :cond_b
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFailed()Z
+
+    .line 395
+    .line 396
+    .line 397
+    move-result v0
+
+    .line 398
+    if-eqz v0, :cond_c
+
+    .line 399
+    .line 400
+    invoke-static {v1, v7}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 401
+    .line 402
+    .line 403
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 404
+    .line 405
+    .line 406
+    move-result-object v0
+
+    .line 407
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getType()Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 408
+    .line 409
+    .line 410
+    move-result-object v1
+
+    .line 411
+    invoke-virtual {p0, v0, v1, p1}, Lcom/random/chat/app/ui/chat/ChatViewModel;->uploadImage(Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 412
+    .line 413
+    .line 414
+    goto :goto_3
+
+    .line 415
+    :cond_c
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isStarted()Z
+
+    .line 416
+    .line 417
+    .line 418
+    move-result p1
+
+    .line 419
+    if-eqz p1, :cond_d
+
+    .line 420
+    .line 421
+    invoke-static {v1, v6}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 422
+    .line 423
+    .line 424
+    goto :goto_3
+
+    .line 425
+    :cond_d
+    invoke-static {v1, v10}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 426
+    .line 427
+    .line 428
+    goto :goto_3
+
+    .line 429
+    :cond_e
+    invoke-static {v1, v5}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 430
+    .line 431
+    .line 432
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getUrl()Ljava/lang/String;
+
+    .line 433
+    .line 434
+    .line 435
+    move-result-object v0
+
+    .line 436
+    invoke-virtual {v0, v4}, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
+
+    .line 437
+    .line 438
+    .line 439
+    move-result v0
+
+    .line 440
+    if-nez v0, :cond_f
+
+    .line 441
+    .line 442
+    invoke-static {v1, v9}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 443
+    .line 444
+    .line 445
+    goto :goto_3
+
+    .line 446
+    :cond_f
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isStarted()Z
+
+    .line 447
+    .line 448
+    .line 449
+    move-result v0
+
+    .line 450
+    if-eqz v0, :cond_12
+
+    .line 451
+    .line 452
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isFailed()Z
+
+    .line 453
+    .line 454
+    .line 455
+    move-result v0
+
+    .line 456
+    if-eqz v0, :cond_10
+
+    .line 457
+    .line 458
+    goto :goto_1
+
+    .line 459
+    :cond_10
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->isStarted()Z
+
+    .line 460
+    .line 461
+    .line 462
+    move-result v0
+
+    .line 463
+    if-eqz v0, :cond_11
+
+    .line 464
+    .line 465
+    invoke-static {v1, v3}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 466
+    .line 467
+    .line 468
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 469
+    .line 470
+    invoke-virtual {v0, p1}, Lcom/random/chat/app/data/controller/MessageController;->stopDownloadMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 471
+    .line 472
+    .line 473
+    goto :goto_3
+
+    .line 474
+    :cond_11
+    invoke-static {v1, v10}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 475
+    .line 476
+    .line 477
+    goto :goto_3
+
+    .line 478
+    :cond_12
+    :goto_1
+    invoke-static {v1, v2}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 479
+    .line 480
+    .line 481
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 482
+    .line 483
+    invoke-virtual {v0, p1}, Lcom/random/chat/app/data/controller/MessageController;->startDownloadMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 484
+    .line 485
+    .line 486
+    goto :goto_3
+
+    .line 487
+    :cond_13
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->onError:Landroidx/lifecycle/MutableLiveData;
+
+    .line 488
+    .line 489
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 490
+    .line 491
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_2
+    .catch Ljava/lang/Exception; {:try_start_2 .. :try_end_2} :catch_0
+
+    .line 492
+    .line 493
+    .line 494
+    goto :goto_3
+
+    .line 495
+    :goto_2
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 496
+    .line 497
+    .line 498
+    :cond_14
+    :goto_3
+    return-void
+    .line 499
+    .line 500
+    .line 501
+    .line 502
+    .line 503
+    .line 504
+    .line 505
+    .line 506
+    .line 507
+    .line 508
+    .line 509
+    .line 510
+    .line 511
+    .line 512
+    .line 513
+    .line 514
+    .line 515
+    .line 516
+    .line 517
+    .line 518
+    .line 519
+    .line 520
+    .line 521
+    .line 522
+    .line 523
+    .line 524
+    .line 525
+    .line 526
+    .line 527
+    .line 528
+    .line 529
+    .line 530
+    .line 531
+    .line 532
+    .line 533
+    .line 534
+    .line 535
+    .line 536
+    .line 537
+    .line 538
+    .line 539
+    .line 540
+    .line 541
+    .line 542
+    .line 543
+    .line 544
+    .line 545
+    .line 546
+    .line 547
+    .line 548
+    .line 549
+    .line 550
+    .line 551
+    .line 552
+    .line 553
+    .line 554
+    .line 555
+    .line 556
+    .line 557
+    .line 558
+    .line 559
+    .line 560
+    .line 561
+    .line 562
+    .line 563
+    .line 564
+    .line 565
+    .line 566
+    .line 567
+    .line 568
+    .line 569
+    .line 570
+    .line 571
+    .line 572
+    .line 573
+    .line 574
+    .line 575
+    .line 576
+    .line 577
+    .line 578
+    .line 579
+    .line 580
+    .line 581
+    .line 582
+    .line 583
+    .line 584
+    .line 585
+    .line 586
+    .line 587
+    .line 588
+    .line 589
+    .line 590
+    .line 591
+    .line 592
+    .line 593
+    .line 594
+    .line 595
+    .line 596
+    .line 597
+    .line 598
+    .line 599
+    .line 600
+    .line 601
+    .line 602
+    .line 603
+    .line 604
+    .line 605
+    .line 606
+    .line 607
+    .line 608
+    .line 609
+    .line 610
+    .line 611
+    .line 612
+    .line 613
+    .line 614
+    .line 615
+    .line 616
+    .line 617
+    .line 618
+    .line 619
+    .line 620
+    .line 621
+    .line 622
+    .line 623
+    .line 624
+    .line 625
+    .line 626
+    .line 627
+    .line 628
+    .line 629
+    .line 630
+    .line 631
+    .line 632
+    .line 633
+    .line 634
+    .line 635
+    .line 636
+    .line 637
+    .line 638
+    .line 639
+    .line 640
+    .line 641
+    .line 642
+    .line 643
+    .line 644
+    .line 645
+    .line 646
+    .line 647
+    .line 648
+    .line 649
+    .line 650
+    .line 651
+    .line 652
+    .line 653
+    .line 654
+    .line 655
+    .line 656
+    .line 657
+    .line 658
+    .line 659
+    .line 660
+    .line 661
+    .line 662
+    .line 663
+    .line 664
+    .line 665
+    .line 666
+    .line 667
+    .line 668
+    .line 669
+    .line 670
+    .line 671
+    .line 672
+    .line 673
+    .line 674
+    .line 675
+    .line 676
+    .line 677
+    .line 678
+    .line 679
+    .line 680
+    .line 681
+    .line 682
+    .line 683
+    .line 684
+    .line 685
+    .line 686
+    .line 687
+    .line 688
+    .line 689
+    .line 690
+    .line 691
+    .line 692
+    .line 693
+    .line 694
+    .line 695
+    .line 696
+    .line 697
+    .line 698
+    .line 699
+    .line 700
+    .line 701
+    .line 702
+    .line 703
+    .line 704
+    .line 705
+    .line 706
+    .line 707
+    .line 708
+    .line 709
+    .line 710
+    .line 711
+    .line 712
+    .line 713
+    .line 714
+    .line 715
+    .line 716
+    .line 717
+    .line 718
+    .line 719
+    .line 720
+    .line 721
+    .line 722
+    .line 723
+    .line 724
+    .line 725
+    .line 726
+    .line 727
+    .line 728
+    .line 729
+    .line 730
+    .line 731
+    .line 732
+    .line 733
+    .line 734
+    .line 735
+    .line 736
+    .line 737
+    .line 738
+    .line 739
+    .line 740
+    .line 741
+    .line 742
+    .line 743
+    .line 744
+    .line 745
+    .line 746
+    .line 747
+    .line 748
+    .line 749
+    .line 750
+    .line 751
+    .line 752
+    .line 753
+    .line 754
+    .line 755
+    .line 756
+    .line 757
+    .line 758
+    .line 759
+    .line 760
+    .line 761
+    .line 762
+    .line 763
+    .line 764
+    .line 765
+    .line 766
+    .line 767
+    .line 768
+    .line 769
+    .line 770
+    .line 771
+    .line 772
+    .line 773
+    .line 774
+    .line 775
+    .line 776
+    .line 777
+    .line 778
+    .line 779
+    .line 780
+    .line 781
+    .line 782
+    .line 783
+    .line 784
+    .line 785
+    .line 786
+    .line 787
+    .line 788
+    .line 789
+    .line 790
+    .line 791
+    .line 792
+    .line 793
+    .line 794
+    .line 795
+    .line 796
+    .line 797
+    .line 798
+    .line 799
+    .line 800
+    .line 801
+    .line 802
+    .line 803
+    .line 804
+    .line 805
+    .line 806
+    .line 807
+    .line 808
+    .line 809
+    .line 810
+    .line 811
+    .line 812
+    .line 813
+    .line 814
+    .line 815
+    .line 816
+    .line 817
+    .line 818
+    .line 819
+    .line 820
+    .line 821
+    .line 822
+    .line 823
+    .line 824
+    .line 825
+    .line 826
+    .line 827
+    .line 828
+    .line 829
+    .line 830
+    .line 831
+    .line 832
+    .line 833
+    .line 834
+    .line 835
+    .line 836
+    .line 837
+    .line 838
+    .line 839
+    .line 840
+    .line 841
+    .line 842
+    .line 843
+    .line 844
+    .line 845
+    .line 846
+    .line 847
+    .line 848
+    .line 849
+    .line 850
+    .line 851
+    .line 852
+    .line 853
+    .line 854
+    .line 855
+    .line 856
+    .line 857
+    .line 858
+    .line 859
+    .line 860
+    .line 861
+    .line 862
+    .line 863
+    .line 864
+    .line 865
+    .line 866
+    .line 867
+    .line 868
+    .line 869
+    .line 870
+    .line 871
+    .line 872
+    .line 873
+    .line 874
+    .line 875
+    .line 876
+    .line 877
+    .line 878
+    .line 879
+    .line 880
+    .line 881
+    .line 882
+    .line 883
+    .line 884
+    .line 885
+    .line 886
+    .line 887
+    .line 888
+    .line 889
+    .line 890
+    .line 891
+    .line 892
+    .line 893
+    .line 894
+    .line 895
+    .line 896
+    .line 897
+    .line 898
+    .line 899
+    .line 900
+    .line 901
+    .line 902
+    .line 903
+    .line 904
+    .line 905
+    .line 906
+    .line 907
+    .line 908
+    .line 909
+    .line 910
+    .line 911
+    .line 912
+    .line 913
+    .line 914
+    .line 915
+    .line 916
+    .line 917
+    .line 918
+    .line 919
+    .line 920
+    .line 921
+    .line 922
+    .line 923
+    .line 924
+    .line 925
+    .line 926
+    .line 927
+    .line 928
+    .line 929
+    .line 930
+    .line 931
+    .line 932
+    .line 933
+    .line 934
+    .line 935
+    .line 936
+    .line 937
+    .line 938
+    .line 939
+    .line 940
+    .line 941
+    .line 942
+    .line 943
+    .line 944
+    .line 945
+    .line 946
+    .line 947
+    .line 948
+    .line 949
+    .line 950
+    .line 951
+    .line 952
+    .line 953
+    .line 954
+    .line 955
+    .line 956
+    .line 957
+    .line 958
+    .line 959
+    .line 960
+    .line 961
+    .line 962
+    .line 963
+    .line 964
+    .line 965
+    .line 966
+    .line 967
+    .line 968
+    .line 969
+    .line 970
+    .line 971
+    .line 972
+    .line 973
+    .line 974
+    .line 975
+    .line 976
+    .line 977
+    .line 978
+    .line 979
+    .line 980
+    .line 981
+    .line 982
+    .line 983
+    .line 984
+    .line 985
+    .line 986
+    .line 987
+    .line 988
+    .line 989
+    .line 990
+    .line 991
+    .line 992
+    .line 993
+    .line 994
+    .line 995
+    .line 996
+    .line 997
+    .line 998
+    .line 999
+    .line 1000
+    .line 1001
+    .line 1002
+    .line 1003
+    .line 1004
+    .line 1005
+    .line 1006
+    .line 1007
+    .line 1008
+    .line 1009
+    .line 1010
+    .line 1011
+    .line 1012
+    .line 1013
+    .line 1014
+    .line 1015
+.end method
+
+.method launchUpload(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 2
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    new-instance v1, Lcom/random/chat/app/ui/chat/a0;
+
+    .line 12
+    .line 13
+    invoke-direct {v1, p0, v0, p1}, Lcom/random/chat/app/ui/chat/a0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 14
+    .line 15
+    .line 16
+    invoke-static {v1}, Lcom/random/chat/app/util/SingletonExecutor;->executeSocket(Ljava/lang/Runnable;)V
+
+    .line 17
+    .line 18
+    .line 19
+    :cond_0
+    return-void
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method loadMore()V
+    .locals 7
+
+    .line 1
+    const/4 v0, 0x0
+
+    .line 2
+    :try_start_0
+    iget-boolean v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->loadingMore:Z
+
+    .line 3
+    .line 4
+    if-nez v1, :cond_4
+
+    .line 5
+    .line 6
+    const/4 v1, 0x1
+
+    .line 7
+    iput-boolean v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->loadingMore:Z
+
+    .line 8
+    .line 9
+    const-string v2, "ChatViewModel"
+
+    .line 10
+    .line 11
+    const-string v3, "load more"
+
+    .line 12
+    .line 13
+    invoke-static {v2, v3}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
+    .line 14
+    .line 15
+    .line 16
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 17
+    .line 18
+    invoke-virtual {v2}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v2
+
+    .line 22
+    check-cast v2, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 23
+    .line 24
+    if-eqz v2, :cond_4
+
+    .line 25
+    .line 26
+    iget-object v3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 27
+    .line 28
+    invoke-interface {v3}, Ljava/util/List;->isEmpty()Z
+
+    .line 29
+    .line 30
+    .line 31
+    move-result v3
+
+    .line 32
+    if-nez v3, :cond_4
+
+    .line 33
+    .line 34
+    iget-boolean v3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->alwaysAcceptImages:Z
+
+    .line 35
+    .line 36
+    if-nez v3, :cond_1
+
+    .line 37
+    .line 38
+    invoke-virtual {v2}, Lcom/random/chat/app/data/entity/TalkChat;->isAllowImages()Z
+
+    .line 39
+    .line 40
+    .line 41
+    move-result v3
+
+    .line 42
+    if-eqz v3, :cond_0
+
+    .line 43
+    .line 44
+    goto :goto_0
+
+    .line 45
+    :cond_0
+    const/4 v1, 0x0
+
+    .line 46
+    goto :goto_0
+
+    .line 47
+    :catchall_0
+    move-exception v1
+
+    .line 48
+    goto :goto_6
+
+    .line 49
+    :catch_0
+    move-exception v1
+
+    .line 50
+    goto :goto_4
+
+    .line 51
+    :cond_1
+    :goto_0
+    invoke-direct {p0}, Lcom/random/chat/app/ui/chat/ChatViewModel;->getFirstMessage()Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 52
+    .line 53
+    .line 54
+    move-result-object v3
+
+    .line 55
+    if-eqz v3, :cond_2
+
+    .line 56
+    .line 57
+    iget-object v4, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 58
+    .line 59
+    invoke-virtual {v2}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 60
+    .line 61
+    .line 62
+    move-result-object v2
+
+    .line 63
+    invoke-virtual {v3}, Lcom/random/chat/app/data/entity/MessageChat;->getId()J
+
+    .line 64
+    .line 65
+    .line 66
+    move-result-wide v5
+
+    .line 67
+    invoke-virtual {v4, v2, v5, v6, v1}, Lcom/random/chat/app/data/controller/MessageController;->loadMore(Ljava/lang/String;JZ)Lcom/random/chat/app/data/entity/MessageList;
+
+    .line 68
+    .line 69
+    .line 70
+    move-result-object v1
+
+    .line 71
+    goto :goto_1
+
+    .line 72
+    :cond_2
+    new-instance v1, Lcom/random/chat/app/data/entity/MessageList;
+
+    .line 73
+    .line 74
+    invoke-direct {v1}, Lcom/random/chat/app/data/entity/MessageList;-><init>()V
+
+    .line 75
+    .line 76
+    .line 77
+    :goto_1
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageList;->getFiltered()Ljava/util/List;
+
+    .line 78
+    .line 79
+    .line 80
+    move-result-object v2
+
+    .line 81
+    invoke-interface {v2}, Ljava/util/List;->isEmpty()Z
+
+    .line 82
+    .line 83
+    .line 84
+    move-result v2
+
+    .line 85
+    if-nez v2, :cond_4
+
+    .line 86
+    .line 87
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageList;->getFiltered()Ljava/util/List;
+
+    .line 88
+    .line 89
+    .line 90
+    move-result-object v1
+
+    .line 91
+    invoke-interface {v1}, Ljava/util/List;->iterator()Ljava/util/Iterator;
+
+    .line 92
+    .line 93
+    .line 94
+    move-result-object v1
+
+    .line 95
+    :goto_2
+    invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+
+    .line 96
+    .line 97
+    .line 98
+    move-result v2
+
+    .line 99
+    if-eqz v2, :cond_3
+
+    .line 100
+    .line 101
+    invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    .line 102
+    .line 103
+    .line 104
+    move-result-object v2
+
+    .line 105
+    check-cast v2, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 106
+    .line 107
+    iget-object v3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 108
+    .line 109
+    invoke-interface {v3, v0, v2}, Ljava/util/List;->add(ILjava/lang/Object;)V
+
+    .line 110
+    .line 111
+    .line 112
+    goto :goto_2
+
+    .line 113
+    :cond_3
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 114
+    .line 115
+    invoke-static {v1}, Lcom/random/chat/app/util/AppUtils;->divideMessageByDate(Ljava/util/List;)Ljava/util/List;
+
+    .line 116
+    .line 117
+    .line 118
+    move-result-object v1
+
+    .line 119
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 120
+    .line 121
+    invoke-interface {v2}, Ljava/util/List;->clear()V
+
+    .line 122
+    .line 123
+    .line 124
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 125
+    .line 126
+    invoke-interface {v2, v1}, Ljava/util/List;->addAll(Ljava/util/Collection;)Z
+
+    .line 127
+    .line 128
+    .line 129
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 130
+    .line 131
+    new-instance v2, Ljava/util/ArrayList;
+
+    .line 132
+    .line 133
+    iget-object v3, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 134
+    .line 135
+    invoke-direct {v2, v3}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 136
+    .line 137
+    .line 138
+    invoke-virtual {v1, v2}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 139
+    .line 140
+    .line 141
+    iput-boolean v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->scrollBottom:Z
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+    .catchall {:try_start_0 .. :try_end_0} :catchall_0
+
+    .line 142
+    .line 143
+    :cond_4
+    :goto_3
+    iput-boolean v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->loadingMore:Z
+
+    .line 144
+    .line 145
+    goto :goto_5
+
+    .line 146
+    :goto_4
+    :try_start_1
+    invoke-static {v1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+    :try_end_1
+    .catchall {:try_start_1 .. :try_end_1} :catchall_0
+
+    .line 147
+    .line 148
+    .line 149
+    goto :goto_3
+
+    .line 150
+    :goto_5
+    return-void
+
+    .line 151
+    :goto_6
+    iput-boolean v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->loadingMore:Z
+
+    .line 152
+    .line 153
+    throw v1
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+    .line 221
+    .line 222
+    .line 223
+    .line 224
+    .line 225
+    .line 226
+    .line 227
+    .line 228
+    .line 229
+    .line 230
+    .line 231
+    .line 232
+    .line 233
+    .line 234
+    .line 235
+.end method
+
+.method markRead()V
+    .locals 2
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/I0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/I0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object v0
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v1
+
+    .line 14
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v1
+
+    .line 18
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v1
+
+    .line 22
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v0
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object v0
+
+    .line 34
+    new-instance v1, Lcom/random/chat/app/ui/chat/J0;
+
+    .line 35
+    .line 36
+    invoke-direct {v1}, Lcom/random/chat/app/ui/chat/J0;-><init>()V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object v0
+
+    .line 43
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method protected onCleared()V
+    .locals 1
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Lio/reactivex/disposables/CompositeDisposable;->e()V
+
+    .line 4
+    .line 5
+    .line 6
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->scheduleRetryAdsThread:Ljava/lang/Thread;
+
+    .line 7
+    .line 8
+    if-eqz v0, :cond_0
+
+    .line 9
+    .line 10
+    invoke-virtual {v0}, Ljava/lang/Thread;->interrupt()V
+
+    .line 11
+    .line 12
+    .line 13
+    :cond_0
+    invoke-super {p0}, Landroidx/lifecycle/ViewModel;->onCleared()V
+
+    .line 14
+    .line 15
+    .line 16
+    return-void
+    .line 17
+    .line 18
+.end method
+
+.method public removeMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 7
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_3
+
+    .line 10
+    .line 11
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdTalk()Ljava/lang/String;
+
+    .line 12
+    .line 13
+    .line 14
+    move-result-object v1
+
+    .line 15
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 16
+    .line 17
+    .line 18
+    move-result-object v0
+
+    .line 19
+    invoke-static {v1, v0}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 20
+    .line 21
+    .line 22
+    move-result v0
+
+    .line 23
+    if-eqz v0, :cond_3
+
+    .line 24
+    .line 25
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 26
+    .line 27
+    invoke-interface {v0}, Ljava/util/List;->iterator()Ljava/util/Iterator;
+
+    .line 28
+    .line 29
+    .line 30
+    move-result-object v0
+
+    .line 31
+    :cond_0
+    invoke-interface {v0}, Ljava/util/Iterator;->hasNext()Z
+
+    .line 32
+    .line 33
+    .line 34
+    move-result v1
+
+    .line 35
+    if-eqz v1, :cond_1
+
+    .line 36
+    .line 37
+    invoke-interface {v0}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    .line 38
+    .line 39
+    .line 40
+    move-result-object v1
+
+    .line 41
+    check-cast v1, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 42
+    .line 43
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 44
+    .line 45
+    .line 46
+    move-result-object v2
+
+    .line 47
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 48
+    .line 49
+    .line 50
+    move-result-object v3
+
+    .line 51
+    invoke-static {v2, v3}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 52
+    .line 53
+    .line 54
+    move-result v2
+
+    .line 55
+    if-nez v2, :cond_2
+
+    .line 56
+    .line 57
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageChat;->getId()J
+
+    .line 58
+    .line 59
+    .line 60
+    move-result-wide v2
+
+    .line 61
+    const-wide/16 v4, 0x0
+
+    .line 62
+    .line 63
+    cmp-long v6, v2, v4
+
+    .line 64
+    .line 65
+    if-eqz v6, :cond_0
+
+    .line 66
+    .line 67
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageChat;->getId()J
+
+    .line 68
+    .line 69
+    .line 70
+    move-result-wide v2
+
+    .line 71
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getId()J
+
+    .line 72
+    .line 73
+    .line 74
+    move-result-wide v4
+
+    .line 75
+    cmp-long v6, v2, v4
+
+    .line 76
+    .line 77
+    if-nez v6, :cond_0
+
+    .line 78
+    .line 79
+    goto :goto_0
+
+    .line 80
+    :catch_0
+    move-exception p1
+
+    .line 81
+    goto :goto_1
+
+    .line 82
+    :cond_1
+    const/4 v1, 0x0
+
+    .line 83
+    :cond_2
+    :goto_0
+    if-eqz v1, :cond_3
+
+    .line 84
+    .line 85
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 86
+    .line 87
+    invoke-interface {p1, v1}, Ljava/util/List;->remove(Ljava/lang/Object;)Z
+
+    .line 88
+    .line 89
+    .line 90
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 91
+    .line 92
+    new-instance v0, Ljava/util/ArrayList;
+
+    .line 93
+    .line 94
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 95
+    .line 96
+    invoke-direct {v0, v1}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 97
+    .line 98
+    .line 99
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 100
+    .line 101
+    .line 102
+    goto :goto_2
+
+    .line 103
+    :goto_1
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 104
+    .line 105
+    .line 106
+    :cond_3
+    :goto_2
+    return-void
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method report(I)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/q0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/q0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;I)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/r0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0}, Lcom/random/chat/app/ui/chat/r0;-><init>()V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method public seekTo(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 3
+
+    .line 1
+    :try_start_0
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 2
+    .line 3
+    .line 4
+    move-result-object v0
+
+    .line 5
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->idPlaying:Ljava/lang/String;
+
+    .line 6
+    .line 7
+    invoke-static {v0, v1}, Lcom/random/chat/app/util/AppUtils;->equalsStr(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 8
+    .line 9
+    .line 10
+    move-result v0
+
+    .line 11
+    if-eqz v0, :cond_0
+
+    .line 12
+    .line 13
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 14
+    .line 15
+    invoke-virtual {v0}, Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;->getMediaPlayer()Landroid/media/MediaPlayer;
+
+    .line 16
+    .line 17
+    .line 18
+    move-result-object v0
+
+    .line 19
+    if-eqz v0, :cond_0
+
+    .line 20
+    .line 21
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 22
+    .line 23
+    invoke-virtual {v0}, Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;->getMediaPlayer()Landroid/media/MediaPlayer;
+
+    .line 24
+    .line 25
+    .line 26
+    move-result-object v0
+
+    .line 27
+    invoke-virtual {v0}, Landroid/media/MediaPlayer;->isPlaying()Z
+
+    .line 28
+    .line 29
+    .line 30
+    move-result v0
+
+    .line 31
+    if-eqz v0, :cond_0
+
+    .line 32
+    .line 33
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->rxAudioPlayer:Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;
+
+    .line 34
+    .line 35
+    invoke-virtual {v0}, Lcom/random/chat/app/ui/chat/androidaudio/RxAudioPlayer;->getMediaPlayer()Landroid/media/MediaPlayer;
+
+    .line 36
+    .line 37
+    .line 38
+    move-result-object v0
+
+    .line 39
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getStartTime()D
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-wide v1
+
+    .line 43
+    double-to-int p1, v1
+
+    .line 44
+    invoke-virtual {v0, p1}, Landroid/media/MediaPlayer;->seekTo(I)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 45
+    .line 46
+    .line 47
+    goto :goto_0
+
+    .line 48
+    :catch_0
+    move-exception p1
+
+    .line 49
+    const-string v0, "ChatViewModel"
+
+    .line 50
+    .line 51
+    const-string v1, "seekTo"
+
+    .line 52
+    .line 53
+    invoke-static {v0, v1, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 54
+    .line 55
+    .line 56
+    :cond_0
+    :goto_0
+    return-void
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method sendMessage(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/U0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/U0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/V0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/V0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method sendTyping(Z)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/H0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/H0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lcom/random/chat/app/util/SingletonExecutor;->execute(Ljava/lang/Runnable;)V
+
+    .line 7
+    .line 8
+    .line 9
+    return-void
+    .line 10
+    .line 11
+    .line 12
+    .line 13
+    .line 14
+    .line 15
+    .line 16
+    .line 17
+    .line 18
+    .line 19
+    .line 20
+    .line 21
+    .line 22
+.end method
+
+.method public startPlay(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 2
+
+    .line 1
+    if-eqz p1, :cond_0
+
+    .line 2
+    .line 3
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getIdServer()Ljava/lang/String;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    invoke-static {v0}, Lcom/random/chat/app/util/AppUtils;->isEmpty(Ljava/lang/String;)Z
+
+    .line 8
+    .line 9
+    .line 10
+    move-result v0
+
+    .line 11
+    if-nez v0, :cond_0
+
+    .line 12
+    .line 13
+    new-instance v0, Lcom/random/chat/app/ui/chat/N0;
+
+    .line 14
+    .line 15
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/N0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 16
+    .line 17
+    .line 18
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v1
+
+    .line 26
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object v1
+
+    .line 34
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 35
+    .line 36
+    .line 37
+    move-result-object v0
+
+    .line 38
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 39
+    .line 40
+    .line 41
+    move-result-object v1
+
+    .line 42
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 43
+    .line 44
+    .line 45
+    move-result-object v0
+
+    .line 46
+    new-instance v1, Lcom/random/chat/app/ui/chat/O0;
+
+    .line 47
+    .line 48
+    invoke-direct {v1, p0, p1}, Lcom/random/chat/app/ui/chat/O0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;)V
+
+    .line 49
+    .line 50
+    .line 51
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 52
+    .line 53
+    .line 54
+    move-result-object p1
+
+    .line 55
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 56
+    .line 57
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 58
+    .line 59
+    .line 60
+    :cond_0
+    return-void
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method public startRecord()V
+    .locals 2
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/k0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/k0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object v0
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v1
+
+    .line 14
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v1
+
+    .line 18
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v1
+
+    .line 22
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v0
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object v0
+
+    .line 34
+    new-instance v1, Lcom/random/chat/app/ui/chat/l0;
+
+    .line 35
+    .line 36
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/l0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object v0
+
+    .line 43
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method public stopPlaying()V
+    .locals 2
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/v0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/v0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object v0
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v1
+
+    .line 14
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v1
+
+    .line 18
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v1
+
+    .line 22
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object v0
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v1
+
+    .line 30
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object v0
+
+    .line 34
+    new-instance v1, Lcom/random/chat/app/ui/chat/w0;
+
+    .line 35
+    .line 36
+    invoke-direct {v1, p0}, Lcom/random/chat/app/ui/chat/w0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {v0, v1}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object v0
+
+    .line 43
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method public stopPlayingStatus()V
+    .locals 5
+
+    .line 1
+    const/4 v0, 0x0
+
+    .line 2
+    const/4 v1, 0x0
+
+    .line 3
+    :goto_0
+    :try_start_0
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 4
+    .line 5
+    invoke-interface {v2}, Ljava/util/List;->size()I
+
+    .line 6
+    .line 7
+    .line 8
+    move-result v2
+
+    .line 9
+    if-ge v1, v2, :cond_1
+
+    .line 10
+    .line 11
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 12
+    .line 13
+    invoke-interface {v2, v1}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    .line 14
+    .line 15
+    .line 16
+    move-result-object v2
+
+    .line 17
+    check-cast v2, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 18
+    .line 19
+    invoke-virtual {v2}, Lcom/random/chat/app/data/entity/MessageChat;->getType()Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 20
+    .line 21
+    .line 22
+    move-result-object v3
+
+    .line 23
+    sget-object v4, Lcom/random/chat/app/data/entity/type/MessageType;->AUDIO:Lcom/random/chat/app/data/entity/type/MessageType;
+
+    .line 24
+    .line 25
+    invoke-virtual {v3, v4}, Ljava/lang/Object;->equals(Ljava/lang/Object;)Z
+
+    .line 26
+    .line 27
+    .line 28
+    move-result v3
+
+    .line 29
+    if-eqz v3, :cond_0
+
+    .line 30
+    .line 31
+    invoke-virtual {v2}, Lcom/random/chat/app/data/entity/MessageChat;->isPlaying()Z
+
+    .line 32
+    .line 33
+    .line 34
+    move-result v3
+
+    .line 35
+    if-eqz v3, :cond_0
+
+    .line 36
+    .line 37
+    invoke-virtual {v2}, Lcom/random/chat/app/data/entity/MessageChat;->clone()Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 38
+    .line 39
+    .line 40
+    move-result-object v2
+
+    .line 41
+    invoke-virtual {v2, v0}, Lcom/random/chat/app/data/entity/MessageChat;->setPlaying(Z)V
+
+    .line 42
+    .line 43
+    .line 44
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 45
+    .line 46
+    invoke-interface {v0, v1, v2}, Ljava/util/List;->set(ILjava/lang/Object;)Ljava/lang/Object;
+
+    .line 47
+    .line 48
+    .line 49
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 50
+    .line 51
+    new-instance v1, Ljava/util/ArrayList;
+
+    .line 52
+    .line 53
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 54
+    .line 55
+    invoke-direct {v1, v2}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 56
+    .line 57
+    .line 58
+    invoke-virtual {v0, v1}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 59
+    .line 60
+    .line 61
+    goto :goto_2
+
+    .line 62
+    :catch_0
+    move-exception v0
+
+    .line 63
+    goto :goto_1
+
+    .line 64
+    :cond_0
+    add-int/lit8 v1, v1, 0x1
+
+    .line 65
+    .line 66
+    goto :goto_0
+
+    .line 67
+    :goto_1
+    const-string v1, "ChatViewModel"
+
+    .line 68
+    .line 69
+    invoke-virtual {v0}, Ljava/lang/Throwable;->getLocalizedMessage()Ljava/lang/String;
+
+    .line 70
+    .line 71
+    .line 72
+    move-result-object v2
+
+    .line 73
+    invoke-static {v1, v2, v0}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 74
+    .line 75
+    .line 76
+    :cond_1
+    :goto_2
+    return-void
+    .line 77
+    .line 78
+    .line 79
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+    .line 221
+    .line 222
+    .line 223
+    .line 224
+    .line 225
+    .line 226
+    .line 227
+    .line 228
+    .line 229
+    .line 230
+    .line 231
+    .line 232
+    .line 233
+    .line 234
+    .line 235
+.end method
+
+.method public stopRecord(Z)V
+    .locals 3
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->audioFile:Ljava/io/File;
+
+    .line 10
+    .line 11
+    if-eqz v1, :cond_1
+
+    .line 12
+    .line 13
+    if-nez v0, :cond_0
+
+    .line 14
+    .line 15
+    goto :goto_0
+
+    .line 16
+    :cond_0
+    new-instance v1, Ljava/io/File;
+
+    .line 17
+    .line 18
+    iget-object v2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->audioFile:Ljava/io/File;
+
+    .line 19
+    .line 20
+    invoke-virtual {v2}, Ljava/io/File;->getPath()Ljava/lang/String;
+
+    .line 21
+    .line 22
+    .line 23
+    move-result-object v2
+
+    .line 24
+    invoke-direct {v1, v2}, Ljava/io/File;-><init>(Ljava/lang/String;)V
+
+    .line 25
+    .line 26
+    .line 27
+    new-instance v2, Lcom/random/chat/app/ui/chat/j0;
+
+    .line 28
+    .line 29
+    invoke-direct {v2, p0, p1, v1, v0}, Lcom/random/chat/app/ui/chat/j0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;ZLjava/io/File;Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 30
+    .line 31
+    .line 32
+    invoke-static {v2}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 33
+    .line 34
+    .line 35
+    move-result-object p1
+
+    .line 36
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 37
+    .line 38
+    .line 39
+    move-result-object v1
+
+    .line 40
+    invoke-virtual {v1}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutorSocket()Ljava/util/concurrent/ExecutorService;
+
+    .line 41
+    .line 42
+    .line 43
+    move-result-object v1
+
+    .line 44
+    invoke-static {v1}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 45
+    .line 46
+    .line 47
+    move-result-object v1
+
+    .line 48
+    invoke-virtual {p1, v1}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 49
+    .line 50
+    .line 51
+    move-result-object p1
+
+    .line 52
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 53
+    .line 54
+    .line 55
+    move-result-object v1
+
+    .line 56
+    invoke-virtual {p1, v1}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 57
+    .line 58
+    .line 59
+    move-result-object p1
+
+    .line 60
+    new-instance v1, Lcom/random/chat/app/ui/chat/u0;
+
+    .line 61
+    .line 62
+    invoke-direct {v1, p0, v0}, Lcom/random/chat/app/ui/chat/u0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 63
+    .line 64
+    .line 65
+    invoke-virtual {p1, v1}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 66
+    .line 67
+    .line 68
+    move-result-object p1
+
+    .line 69
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 70
+    .line 71
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 72
+    .line 73
+    .line 74
+    goto :goto_2
+
+    .line 75
+    :catch_0
+    move-exception p1
+
+    .line 76
+    goto :goto_1
+
+    .line 77
+    :cond_1
+    :goto_0
+    return-void
+
+    .line 78
+    :goto_1
+    const-string v0, "ChatViewModel"
+
+    .line 79
+    .line 80
+    invoke-virtual {p1}, Ljava/lang/Throwable;->getLocalizedMessage()Ljava/lang/String;
+
+    .line 81
+    .line 82
+    .line 83
+    move-result-object v1
+
+    .line 84
+    invoke-static {v0, v1, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 85
+    .line 86
+    .line 87
+    invoke-static {p1}, Lcom/random/chat/app/util/AppUtils;->logException(Ljava/lang/Throwable;)V
+
+    .line 88
+    .line 89
+    .line 90
+    :goto_2
+    return-void
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+    .line 127
+    .line 128
+    .line 129
+    .line 130
+    .line 131
+    .line 132
+    .line 133
+    .line 134
+    .line 135
+    .line 136
+    .line 137
+    .line 138
+    .line 139
+    .line 140
+    .line 141
+    .line 142
+    .line 143
+    .line 144
+    .line 145
+    .line 146
+    .line 147
+    .line 148
+    .line 149
+    .line 150
+    .line 151
+    .line 152
+    .line 153
+    .line 154
+    .line 155
+    .line 156
+    .line 157
+    .line 158
+    .line 159
+    .line 160
+    .line 161
+    .line 162
+    .line 163
+    .line 164
+    .line 165
+    .line 166
+    .line 167
+    .line 168
+    .line 169
+    .line 170
+    .line 171
+    .line 172
+    .line 173
+    .line 174
+    .line 175
+    .line 176
+    .line 177
+    .line 178
+    .line 179
+    .line 180
+    .line 181
+    .line 182
+    .line 183
+    .line 184
+    .line 185
+    .line 186
+    .line 187
+    .line 188
+    .line 189
+    .line 190
+    .line 191
+    .line 192
+    .line 193
+    .line 194
+    .line 195
+    .line 196
+    .line 197
+    .line 198
+    .line 199
+    .line 200
+    .line 201
+    .line 202
+    .line 203
+    .line 204
+    .line 205
+    .line 206
+    .line 207
+    .line 208
+    .line 209
+    .line 210
+    .line 211
+    .line 212
+    .line 213
+    .line 214
+    .line 215
+    .line 216
+    .line 217
+    .line 218
+    .line 219
+    .line 220
+.end method
+
+.method unsubscribePresence()V
+    .locals 2
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 12
+    .line 13
+    .line 14
+    move-result-object v1
+
+    .line 15
+    if-eqz v1, :cond_0
+
+    .line 16
+    .line 17
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->presenceController:Lcom/random/chat/app/data/controller/PresenceController;
+
+    .line 18
+    .line 19
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdProfile()Ljava/lang/String;
+
+    .line 20
+    .line 21
+    .line 22
+    move-result-object v0
+
+    .line 23
+    invoke-virtual {v1, v0}, Lcom/random/chat/app/data/controller/PresenceController;->unsubscribePresence(Ljava/lang/String;)V
+
+    .line 24
+    .line 25
+    .line 26
+    :cond_0
+    return-void
+    .line 27
+    .line 28
+    .line 29
+    .line 30
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method updateFavorite(Z)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/P0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/P0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Z)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/schedulers/Schedulers;->d()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/R0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0}, Lcom/random/chat/app/ui/chat/R0;-><init>()V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method public updateMessageInListEvent(Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 6
+
+    .line 1
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->clone()Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 2
+    .line 3
+    .line 4
+    move-result-object p1
+
+    .line 5
+    const/4 v0, 0x0
+
+    .line 6
+    :goto_0
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 7
+    .line 8
+    invoke-interface {v1}, Ljava/util/List;->size()I
+
+    .line 9
+    .line 10
+    .line 11
+    move-result v1
+
+    .line 12
+    if-ge v0, v1, :cond_1
+
+    .line 13
+    .line 14
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 15
+    .line 16
+    invoke-interface {v1, v0}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    .line 17
+    .line 18
+    .line 19
+    move-result-object v1
+
+    .line 20
+    check-cast v1, Lcom/random/chat/app/data/entity/MessageChat;
+
+    .line 21
+    .line 22
+    invoke-virtual {v1}, Lcom/random/chat/app/data/entity/MessageChat;->getId()J
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-wide v1
+
+    .line 26
+    invoke-virtual {p1}, Lcom/random/chat/app/data/entity/MessageChat;->getId()J
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-wide v3
+
+    .line 30
+    cmp-long v5, v1, v3
+
+    .line 31
+    .line 32
+    if-nez v5, :cond_0
+
+    .line 33
+    .line 34
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 35
+    .line 36
+    invoke-interface {v1, v0, p1}, Ljava/util/List;->set(ILjava/lang/Object;)Ljava/lang/Object;
+
+    .line 37
+    .line 38
+    .line 39
+    goto :goto_1
+
+    .line 40
+    :cond_0
+    add-int/lit8 v0, v0, 0x1
+
+    .line 41
+    .line 42
+    goto :goto_0
+
+    .line 43
+    :cond_1
+    :goto_1
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messages:Landroidx/lifecycle/MutableLiveData;
+
+    .line 44
+    .line 45
+    new-instance v0, Ljava/util/ArrayList;
+
+    .line 46
+    .line 47
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messagesCached:Ljava/util/List;
+
+    .line 48
+    .line 49
+    invoke-direct {v0, v1}, Ljava/util/ArrayList;-><init>(Ljava/util/Collection;)V
+
+    .line 50
+    .line 51
+    .line 52
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 53
+    .line 54
+    .line 55
+    return-void
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method public uploadBlocked()Ljava/util/Date;
+    .locals 3
+
+    .line 1
+    :try_start_0
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->userController:Lcom/random/chat/app/data/controller/UserController;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Lcom/random/chat/app/data/controller/UserController;->getUser()Lcom/random/chat/app/data/entity/User;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/User;->getUserConfig()Lcom/random/chat/app/data/entity/UserConfig;
+
+    .line 8
+    .line 9
+    .line 10
+    move-result-object v0
+
+    .line 11
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/UserConfig;->isUploadBlocked()Z
+
+    .line 12
+    .line 13
+    .line 14
+    move-result v0
+
+    .line 15
+    if-eqz v0, :cond_0
+
+    .line 16
+    .line 17
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->userController:Lcom/random/chat/app/data/controller/UserController;
+
+    .line 18
+    .line 19
+    invoke-virtual {v0}, Lcom/random/chat/app/data/controller/UserController;->getUser()Lcom/random/chat/app/data/entity/User;
+
+    .line 20
+    .line 21
+    .line 22
+    move-result-object v0
+
+    .line 23
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/User;->getUserConfig()Lcom/random/chat/app/data/entity/UserConfig;
+
+    .line 24
+    .line 25
+    .line 26
+    move-result-object v0
+
+    .line 27
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/UserConfig;->getUploadBlockedTime()Ljava/util/Date;
+
+    .line 28
+    .line 29
+    .line 30
+    move-result-object v0
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    .line 31
+    return-object v0
+
+    .line 32
+    :catch_0
+    move-exception v0
+
+    .line 33
+    const-string v1, "ChatViewModel"
+
+    .line 34
+    .line 35
+    invoke-virtual {v0}, Ljava/lang/Throwable;->getLocalizedMessage()Ljava/lang/String;
+
+    .line 36
+    .line 37
+    .line 38
+    move-result-object v2
+
+    .line 39
+    invoke-static {v1, v2, v0}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 40
+    .line 41
+    .line 42
+    :cond_0
+    const/4 v0, 0x0
+
+    .line 43
+    return-object v0
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+.end method
+
+.method uploadImage(Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/MessageChat;)V
+    .locals 8
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    new-instance v7, Lcom/random/chat/app/ui/chat/F0;
+
+    .line 12
+    .line 13
+    move-object v1, v7
+
+    .line 14
+    move-object v2, p0
+
+    .line 15
+    move-object v3, p3
+
+    .line 16
+    move-object v4, p1
+
+    .line 17
+    move-object v5, p2
+
+    .line 18
+    move-object v6, v0
+
+    .line 19
+    invoke-direct/range {v1 .. v6}, Lcom/random/chat/app/ui/chat/F0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/MessageChat;Ljava/lang/String;Lcom/random/chat/app/data/entity/type/MessageType;Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 20
+    .line 21
+    .line 22
+    invoke-static {v7}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object p2
+
+    .line 30
+    invoke-virtual {p2}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p2
+
+    .line 34
+    invoke-static {p2}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 35
+    .line 36
+    .line 37
+    move-result-object p2
+
+    .line 38
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 39
+    .line 40
+    .line 41
+    move-result-object p1
+
+    .line 42
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 43
+    .line 44
+    .line 45
+    move-result-object p2
+
+    .line 46
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 47
+    .line 48
+    .line 49
+    move-result-object p1
+
+    .line 50
+    new-instance p2, Lcom/random/chat/app/ui/chat/Q0;
+
+    .line 51
+    .line 52
+    invoke-direct {p2, p0, v0}, Lcom/random/chat/app/ui/chat/Q0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/data/entity/TalkChat;)V
+
+    .line 53
+    .line 54
+    .line 55
+    invoke-virtual {p1, p2}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 56
+    .line 57
+    .line 58
+    move-result-object p1
+
+    .line 59
+    iget-object p2, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 60
+    .line 61
+    invoke-virtual {p2, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 62
+    .line 63
+    .line 64
+    :cond_0
+    return-void
+    .line 65
+    .line 66
+    .line 67
+    .line 68
+    .line 69
+    .line 70
+    .line 71
+    .line 72
+    .line 73
+    .line 74
+    .line 75
+    .line 76
+    .line 77
+    .line 78
+    .line 79
+    .line 80
+    .line 81
+    .line 82
+    .line 83
+    .line 84
+    .line 85
+    .line 86
+    .line 87
+    .line 88
+    .line 89
+    .line 90
+    .line 91
+    .line 92
+    .line 93
+    .line 94
+    .line 95
+    .line 96
+    .line 97
+    .line 98
+    .line 99
+    .line 100
+    .line 101
+    .line 102
+    .line 103
+    .line 104
+    .line 105
+    .line 106
+    .line 107
+    .line 108
+    .line 109
+    .line 110
+    .line 111
+    .line 112
+    .line 113
+    .line 114
+    .line 115
+    .line 116
+    .line 117
+    .line 118
+    .line 119
+    .line 120
+    .line 121
+    .line 122
+    .line 123
+    .line 124
+    .line 125
+    .line 126
+.end method
+
+.method validatePaste(Ljava/lang/String;)V
+    .locals 2
+
+    .line 1
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->talk:Landroidx/lifecycle/MutableLiveData;
+
+    .line 2
+    .line 3
+    invoke-virtual {v0}, Landroidx/lifecycle/LiveData;->f()Ljava/lang/Object;
+
+    .line 4
+    .line 5
+    .line 6
+    move-result-object v0
+
+    .line 7
+    check-cast v0, Lcom/random/chat/app/data/entity/TalkChat;
+
+    .line 8
+    .line 9
+    if-eqz v0, :cond_0
+
+    .line 10
+    .line 11
+    iget-object v1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->messageController:Lcom/random/chat/app/data/controller/MessageController;
+
+    .line 12
+    .line 13
+    invoke-virtual {v0}, Lcom/random/chat/app/data/entity/TalkChat;->getIdServer()Ljava/lang/String;
+
+    .line 14
+    .line 15
+    .line 16
+    move-result-object v0
+
+    .line 17
+    invoke-virtual {v1, v0, p1}, Lcom/random/chat/app/data/controller/MessageController;->canPaste(Ljava/lang/String;Ljava/lang/String;)Z
+
+    .line 18
+    .line 19
+    .line 20
+    move-result p1
+
+    .line 21
+    if-nez p1, :cond_0
+
+    .line 22
+    .line 23
+    iget-object p1, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->alertSpam:Landroidx/lifecycle/MutableLiveData;
+
+    .line 24
+    .line 25
+    sget-object v0, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    .line 26
+    .line 27
+    invoke-virtual {p1, v0}, Landroidx/lifecycle/MutableLiveData;->m(Ljava/lang/Object;)V
+
+    .line 28
+    .line 29
+    .line 30
+    :cond_0
+    return-void
+    .line 31
+    .line 32
+    .line 33
+    .line 34
+    .line 35
+    .line 36
+    .line 37
+    .line 38
+    .line 39
+    .line 40
+    .line 41
+    .line 42
+    .line 43
+    .line 44
+    .line 45
+    .line 46
+    .line 47
+    .line 48
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method verifyCanSend(I)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/m0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/m0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;I)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/n0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/n0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method
+
+.method verifyCanShare(Lcom/random/chat/app/ui/chat/FileShareObject;)V
+    .locals 1
+
+    .line 1
+    new-instance v0, Lcom/random/chat/app/ui/chat/o0;
+
+    .line 2
+    .line 3
+    invoke-direct {v0, p0, p1}, Lcom/random/chat/app/ui/chat/o0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;Lcom/random/chat/app/ui/chat/FileShareObject;)V
+
+    .line 4
+    .line 5
+    .line 6
+    invoke-static {v0}, Lio/reactivex/Single;->b(Ljava/util/concurrent/Callable;)Lio/reactivex/Single;
+
+    .line 7
+    .line 8
+    .line 9
+    move-result-object p1
+
+    .line 10
+    invoke-static {}, Lcom/random/chat/app/util/SingletonExecutor;->getInstance()Lcom/random/chat/app/util/SingletonExecutor;
+
+    .line 11
+    .line 12
+    .line 13
+    move-result-object v0
+
+    .line 14
+    invoke-virtual {v0}, Lcom/random/chat/app/util/SingletonExecutor;->getExecutor()Ljava/util/concurrent/ExecutorService;
+
+    .line 15
+    .line 16
+    .line 17
+    move-result-object v0
+
+    .line 18
+    invoke-static {v0}, Lio/reactivex/schedulers/Schedulers;->b(Ljava/util/concurrent/Executor;)Lio/reactivex/Scheduler;
+
+    .line 19
+    .line 20
+    .line 21
+    move-result-object v0
+
+    .line 22
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->g(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 23
+    .line 24
+    .line 25
+    move-result-object p1
+
+    .line 26
+    invoke-static {}, Lio/reactivex/android/schedulers/AndroidSchedulers;->a()Lio/reactivex/Scheduler;
+
+    .line 27
+    .line 28
+    .line 29
+    move-result-object v0
+
+    .line 30
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->c(Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+
+    .line 31
+    .line 32
+    .line 33
+    move-result-object p1
+
+    .line 34
+    new-instance v0, Lcom/random/chat/app/ui/chat/p0;
+
+    .line 35
+    .line 36
+    invoke-direct {v0, p0}, Lcom/random/chat/app/ui/chat/p0;-><init>(Lcom/random/chat/app/ui/chat/ChatViewModel;)V
+
+    .line 37
+    .line 38
+    .line 39
+    invoke-virtual {p1, v0}, Lio/reactivex/Single;->d(Lio/reactivex/functions/Consumer;)Lio/reactivex/disposables/Disposable;
+
+    .line 40
+    .line 41
+    .line 42
+    move-result-object p1
+
+    .line 43
+    iget-object v0, p0, Lcom/random/chat/app/ui/chat/ChatViewModel;->disposable:Lio/reactivex/disposables/CompositeDisposable;
+
+    .line 44
+    .line 45
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->b(Lio/reactivex/disposables/Disposable;)Z
+
+    .line 46
+    .line 47
+    .line 48
+    return-void
+    .line 49
+    .line 50
+    .line 51
+    .line 52
+    .line 53
+    .line 54
+    .line 55
+    .line 56
+    .line 57
+    .line 58
+    .line 59
+    .line 60
+    .line 61
+    .line 62
+    .line 63
+    .line 64
+    .line 65
+    .line 66
+    .line 67
+.end method


### PR DESCRIPTION
Desativei o alerta de spam por colagem no ChatViewModel para você.

Para fazer isso, modifiquei o método `validatePaste` em `ChatViewModel.smali`, comentando as linhas que atualizam o `LiveData alertSpam`. Isso impede que o diálogo de alerta de spam por copiar e colar seja acionado, independentemente da lógica (atualmente permissiva) no `MessageController.canPaste`.

A infraestrutura para detecção de spam (`SpamPasteCheck` e `spamPasteCheckMap` no `MessageController`) permanece, mas não é ativamente usada para disparar este alerta específico após esta modificação no ChatViewModel.